### PR TITLE
Handle special character in enums

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -109,6 +109,12 @@ function getSystemFields(type) {
 function getOptionEnumName(recordName, fieldName) {
   return `${toPascalCase(recordName)}${toPascalCase(fieldName)}Options`;
 }
+function getOptionValues(field) {
+  const values = field.options.values;
+  if (!values)
+    return [];
+  return values.filter((val, i) => values.indexOf(val) === i);
+}
 
 // src/lib.ts
 var pbSchemaTypescriptMap = {
@@ -201,13 +207,10 @@ function createTypeField(collectionName, fieldSchema) {
 function createSelectOptions(recordName, schema) {
   const selectFields = schema.filter((field) => field.type === "select");
   const typestring = selectFields.map(
-    (field) => {
-      var _a;
-      return `export enum ${getOptionEnumName(recordName, field.name)} {
-${(_a = field.options.values) == null ? void 0 : _a.map((val) => `	${val} = "${val}",`).join("\n")}
+    (field) => `export enum ${getOptionEnumName(recordName, field.name)} {
+${getOptionValues(field).map((val) => `	"${val}" = "${val}",`).join("\n")}
 }
-`;
-    }
+`
   ).join("\n");
   return typestring;
 }
@@ -235,7 +238,7 @@ async function main(options2) {
 import { program } from "commander";
 
 // package.json
-var version = "1.1.0";
+var version = "1.1.1";
 
 // src/index.ts
 program.name("Pocketbase Typegen").version(version).description(

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "modulePathIgnorePatterns": [
-      "<rootDir>/dist/",
-      "<rootDir>/test/pocketbase-types-examples.ts"
+      "dist",
+      "pocketbase-types-examples.ts"
     ]
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate pocketbase record types from your database",
   "main": "dist/index.js",
   "bin": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -16,6 +16,7 @@ import {
 } from "./generics"
 import {
   getOptionEnumName,
+  getOptionValues,
   getSystemFields,
   sanitizeFieldName,
   toPascalCase,
@@ -164,7 +165,9 @@ export function createSelectOptions(
   const typestring = selectFields
     .map(
       (field) => `export enum ${getOptionEnumName(recordName, field.name)} {
-${field.options.values?.map((val) => `\t${val} = "${val}",`).join("\n")}
+${getOptionValues(field)
+  .map((val) => `\t"${val}" = "${val}",`)
+  .join("\n")}
 }\n`
     )
     .join("\n")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { CollectionRecord } from "./types"
+import { CollectionRecord, FieldSchema } from "./types"
+
 import { promises as fs } from "fs"
 
 export function toPascalCase(str: string) {
@@ -30,4 +31,10 @@ export function getSystemFields(type: CollectionRecord["type"]) {
 
 export function getOptionEnumName(recordName: string, fieldName: string) {
   return `${toPascalCase(recordName)}${toPascalCase(fieldName)}Options`
+}
+
+export function getOptionValues(field: FieldSchema) {
+  const values = field.options.values
+  if (!values) return []
+  return values.filter((val, i) => values.indexOf(val) === i)
 }

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -45,9 +45,12 @@ export type CustomAuthRecord = {
 }
 
 export enum EverythingSelectFieldOptions {
-	optionA = "optionA",
-	optionB = "optionB",
-	optionC = "optionC",
+	"optionA" = "optionA",
+	"OptionA" = "OptionA",
+	"optionB" = "optionB",
+	"optionC" = "optionC",
+	"option with space" = "option with space",
+	"sy?mb@!$" = "sy?mb@!$",
 }
 export type EverythingRecord<Tanother_json_field = unknown, Tjson_field = unknown> = {
 	text_field?: string

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -34,6 +34,16 @@ exports[`createResponseType handles file fields with multiple files 1`] = `
 }"
 `;
 
+exports[`createSelectOptions creates enum types for select options 1`] = `
+"export enum ChooseTitleOptions {
+	"one" = "one",
+	"two" = "two",
+	"space space" = "space space",
+	"$@#*(&#%" = "$@#*(&#%",
+}
+"
+`;
+
 exports[`generate generates correct output given db input 1`] = `
 "/**
 * This file was @generated using pocketbase-typegen

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -4,6 +4,7 @@ import {
   createCollectionRecords,
   createRecordType,
   createResponseType,
+  createSelectOptions,
   createTypeField,
   generate,
 } from "../src/lib"
@@ -324,5 +325,24 @@ describe("createTypeField", () => {
         type: "unknowntype",
       })
     ).toThrowError("unknown type unknowntype found in schema")
+  })
+})
+
+describe("createSelectOptions", () => {
+  it("creates enum types for select options", () => {
+    const name = "choose"
+    const schema: FieldSchema[] = [
+      {
+        system: false,
+        id: "hhnwjkke",
+        name: "title",
+        type: "select",
+        required: false,
+        unique: false,
+        options: { values: ["one", "one", "two", "space space", "$@#*(&#%"] },
+      },
+    ]
+    const result = createSelectOptions(name, schema)
+    expect(result).toMatchSnapshot()
   })
 })

--- a/test/pb_schema.json
+++ b/test/pb_schema.json
@@ -140,7 +140,15 @@
         "unique": false,
         "options": {
           "maxSelect": 1,
-          "values": ["optionA", "optionB", "optionC"]
+          "values": [
+            "optionA",
+            "optionA",
+            "OptionA",
+            "optionB",
+            "optionC",
+            "option with space",
+            "sy?mb@!$"
+          ]
         }
       },
       {
@@ -242,11 +250,11 @@
         }
       }
     ],
-    "listRule": null,
-    "viewRule": null,
-    "createRule": null,
-    "updateRule": null,
-    "deleteRule": null,
+    "listRule": "",
+    "viewRule": "",
+    "createRule": "",
+    "updateRule": "",
+    "deleteRule": "",
     "options": {}
   },
   {

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -42,9 +42,12 @@ export type CustomAuthRecord = {
 }
 
 export enum EverythingSelectFieldOptions {
-	optionA = "optionA",
-	optionB = "optionB",
-	optionC = "optionC",
+	"optionA" = "optionA",
+	"OptionA" = "OptionA",
+	"optionB" = "optionB",
+	"optionC" = "optionC",
+	"option with space" = "option with space",
+	"sy?mb@!$" = "sy?mb@!$",
 }
 export type EverythingRecord<Tanother_json_field = unknown, Tjson_field = unknown> = {
 	text_field?: string

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,9 +1,12 @@
 import {
   getOptionEnumName,
+  getOptionValues,
   getSystemFields,
   sanitizeFieldName,
   toPascalCase,
 } from "../src/utils"
+
+import { FieldSchema } from "../src/types"
 
 describe("toPascalCase", () => {
   it("return pascal case string", () => {
@@ -41,5 +44,35 @@ describe("getOptionEnumName", () => {
     expect(getOptionEnumName("orders_with_underscore", "type_underscore")).toBe(
       "OrdersWithUnderscoreTypeUnderscoreOptions"
     )
+  })
+})
+
+describe("getOptionValues", () => {
+  it("returns empty array when no select field values", () => {
+    const fieldWithoutValues: FieldSchema = {
+      id: "1",
+      name: "myfield",
+      type: "text",
+      system: false,
+      required: false,
+      unique: false,
+      options: {},
+    }
+    expect(getOptionValues(fieldWithoutValues)).toEqual([])
+  })
+
+  it("returns deduped select field values", () => {
+    const fieldWithValues: FieldSchema = {
+      id: "1",
+      name: "myfield",
+      type: "text",
+      system: false,
+      required: false,
+      unique: false,
+      options: {
+        values: ["one", "one", "one", "two"],
+      },
+    }
+    expect(getOptionValues(fieldWithValues)).toEqual(["one", "two"])
   })
 })


### PR DESCRIPTION
Fix handling of spaces and special characters in enums by quoting enum keys.

eg:
```typescript
export enum EverythingSelectFieldOptions {
	"optionA" = "optionA",
	"OptionA" = "OptionA",
	"optionB" = "optionB",
	"optionC" = "optionC",
	"option with space" = "option with space",
	"sy?mb@!$" = "sy?mb@!$",
}
```
also de-dupe select field values.

fixes https://github.com/patmood/pocketbase-typegen/issues/21