### PR TITLE
handle select fields with maxSelect > 1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -124,7 +124,10 @@ var pbSchemaTypescriptMap = {
   email: "string",
   url: "string",
   date: DATE_STRING_TYPE_NAME,
-  select: (fieldSchema, collectionName) => fieldSchema.options.values ? getOptionEnumName(collectionName, fieldSchema.name) : "string",
+  select: (fieldSchema, collectionName) => {
+    const valueType = fieldSchema.options.values ? getOptionEnumName(collectionName, fieldSchema.name) : "string";
+    return fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? `${valueType}[]` : valueType;
+  },
   json: (fieldSchema) => `null | ${fieldNameToGeneric(fieldSchema.name)}`,
   file: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? "string[]" : "string",
   relation: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? `${RECORD_ID_STRING_NAME}[]` : RECORD_ID_STRING_NAME,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -29,10 +29,15 @@ const pbSchemaTypescriptMap = {
   email: "string",
   url: "string",
   date: DATE_STRING_TYPE_NAME,
-  select: (fieldSchema: FieldSchema, collectionName: string) =>
-    fieldSchema.options.values
+  select: (fieldSchema: FieldSchema, collectionName: string) => {
+    // pocketbase v0.8+ values are required
+    const valueType = fieldSchema.options.values
       ? getOptionEnumName(collectionName, fieldSchema.name)
-      : "string",
+      : "string"
+    return fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1
+      ? `${valueType}[]`
+      : valueType
+  },
   json: (fieldSchema: FieldSchema) =>
     `null | ${fieldNameToGeneric(fieldSchema.name)}`,
   file: (fieldSchema: FieldSchema) =>

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -250,6 +250,35 @@ describe("createTypeField", () => {
     ).toEqual(`\tselectFieldWithOpts: TestCollectionSelectFieldWithOptsOptions`)
   })
 
+  it("converts multi-select type", () => {
+    expect(
+      createTypeField("test_collection", {
+        ...defaultFieldSchema,
+        name: "selectField",
+        type: "select",
+        options: {
+          maxSelect: 2,
+        },
+      })
+    ).toEqual("\tselectField: string[]")
+  })
+
+  it("converts multi-select type with values", () => {
+    expect(
+      createTypeField("test_collection", {
+        ...defaultFieldSchema,
+        name: "selectFieldWithOpts",
+        type: "select",
+        options: {
+          values: ["one", "two", "three"],
+          maxSelect: 2,
+        },
+      })
+    ).toEqual(
+      `\tselectFieldWithOpts: TestCollectionSelectFieldWithOptsOptions[]`
+    )
+  })
+
   it("converts json type", () => {
     expect(
       createTypeField("test_collection", {


### PR DESCRIPTION
select fields that have maxSelect > 1 should use an array type

fixes https://github.com/patmood/pocketbase-typegen/issues/24