### PR TITLE
handle relation fields with maxSelect = null

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -45,9 +45,9 @@ const pbSchemaTypescriptMap = {
       ? "string[]"
       : "string",
   relation: (fieldSchema: FieldSchema) =>
-    fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1
-      ? `${RECORD_ID_STRING_NAME}[]`
-      : RECORD_ID_STRING_NAME,
+    fieldSchema.options.maxSelect && fieldSchema.options.maxSelect === 1
+      ? RECORD_ID_STRING_NAME
+      : `${RECORD_ID_STRING_NAME}[]`,
   // DEPRECATED: PocketBase v0.8 does not have a dedicated user relation
   user: (fieldSchema: FieldSchema) =>
     fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -319,7 +319,7 @@ describe("createTypeField", () => {
         name: "relationField",
         type: "relation",
       })
-    ).toEqual("\trelationField: RecordIdString")
+    ).toEqual("\trelationField: RecordIdString[]")
   })
 
   it("converts relation type with multiple options", () => {
@@ -330,6 +330,19 @@ describe("createTypeField", () => {
         type: "relation",
         options: {
           maxSelect: 3,
+        },
+      })
+    ).toEqual("\trelationFieldMany: RecordIdString[]")
+  })
+
+  it("converts relation type with unset maxSelect", () => {
+    expect(
+      createTypeField("test_collection", {
+        ...defaultFieldSchema,
+        name: "relationFieldMany",
+        type: "relation",
+        options: {
+          maxSelect: null,
         },
       })
     ).toEqual("\trelationFieldMany: RecordIdString[]")


### PR DESCRIPTION
when maxSelect = null (left empty), it accepts unlimitted number of values

![CleanShot 2023-01-02 at 15 40 44](https://user-images.githubusercontent.com/10374235/210209371-82402595-dd24-4212-b056-5b4bd804730e.png)
