### PR TITLE
Add expand types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .DS_Store
 fixtures
 examples
+.vscode

--- a/dist/index.js
+++ b/dist/index.js
@@ -213,7 +213,7 @@ function createExpandType(allRecords, targetRecord) {
   const expandTypesString = `type ${pascaleName}ExpandType = {
 ${hasExpandTypes ? expandTypes.join("\n") : "	// Doesn't have any relation"}
 }`;
-  const expandConstString = hasExpandTypes && `export const ${pascaleName}Expand = {
+  const expandConstString = hasExpandTypes && `export const ${pascaleName}ExpandKeys = {
   ${expandConsts.join(",\n")}
 }`;
   return [expandTypesString, expandConstString].filter(Boolean).join("\n");

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,26 +43,27 @@ var EXPORT_COMMENT = `/**
 */`;
 var RECORD_TYPE_COMMENT = `// Record types for each collection`;
 var RESPONSE_TYPE_COMMENT = `// Response types include system fields and match responses from the PocketBase API`;
+var EXPAND_TYPE_COMMENT = `// Expand types are used to define the expand object in the PocketBase API`;
 var DATE_STRING_TYPE_NAME = `IsoDateString`;
 var RECORD_ID_STRING_NAME = `RecordIdString`;
 var ALIAS_TYPE_DEFINITIONS = `// Alias types for improved usability
 export type ${DATE_STRING_TYPE_NAME} = string
 export type ${RECORD_ID_STRING_NAME} = string`;
 var BASE_SYSTEM_FIELDS_DEFINITION = `// System fields
-export type BaseSystemFields = {
+export type BaseSystemFields<T> = {
 	id: ${RECORD_ID_STRING_NAME}
 	created: ${DATE_STRING_TYPE_NAME}
 	updated: ${DATE_STRING_TYPE_NAME}
 	collectionId: string
 	collectionName: Collections
-	expand?: { [key: string]: any }
+	expand?: T extends object ? T : never
 }`;
 var AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields = {
 	email: string
 	emailVisibility: boolean
 	username: string
 	verified: boolean
-} & BaseSystemFields`;
+}`;
 
 // src/generics.ts
 function fieldNameToGeneric(name) {
@@ -103,9 +104,6 @@ async function saveFile(outPath, typeString) {
   await fs2.writeFile(outPath, typeString, "utf8");
   console.log(`Created typescript definitions at ${outPath}`);
 }
-function getSystemFields(type) {
-  return type === "auth" ? "AuthSystemFields" : "BaseSystemFields";
-}
 function getOptionEnumName(recordName, fieldName) {
   return `${toPascalCase(recordName)}${toPascalCase(fieldName)}Options`;
 }
@@ -130,12 +128,13 @@ var pbSchemaTypescriptMap = {
   },
   json: (fieldSchema) => `null | ${fieldNameToGeneric(fieldSchema.name)}`,
   file: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? "string[]" : "string",
-  relation: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? `${RECORD_ID_STRING_NAME}[]` : RECORD_ID_STRING_NAME,
+  relation: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect === 1 ? RECORD_ID_STRING_NAME : `${RECORD_ID_STRING_NAME}[]`,
   user: (fieldSchema) => fieldSchema.options.maxSelect && fieldSchema.options.maxSelect > 1 ? `${RECORD_ID_STRING_NAME}[]` : RECORD_ID_STRING_NAME
 };
 function generate(results) {
   const collectionNames = [];
   const recordTypes = [];
+  const expandTypes = [EXPAND_TYPE_COMMENT];
   const responseTypes = [RESPONSE_TYPE_COMMENT];
   results.sort((a, b) => {
     if (a.name < b.name) {
@@ -151,6 +150,7 @@ function generate(results) {
     if (row.schema) {
       recordTypes.push(createRecordType(row.name, row.schema));
       responseTypes.push(createResponseType(row));
+      expandTypes.push(createExpandType(results, row));
     }
   });
   const sortedCollectionNames = collectionNames;
@@ -162,6 +162,7 @@ function generate(results) {
     AUTH_SYSTEM_FIELDS_DEFINITION,
     RECORD_TYPE_COMMENT,
     ...recordTypes,
+    expandTypes.join("\n"),
     responseTypes.join("\n"),
     createCollectionRecords(sortedCollectionNames)
   ];
@@ -194,8 +195,66 @@ function createResponseType(collectionSchemaEntry) {
   const pascaleName = toPascalCase(name);
   const genericArgsWithDefaults = getGenericArgStringWithDefault(schema);
   const genericArgs = getGenericArgString(schema);
-  const systemFields = getSystemFields(type);
-  return `export type ${pascaleName}Response${genericArgsWithDefaults} = ${pascaleName}Record${genericArgs} & ${systemFields}`;
+  return `export type ${pascaleName}Response${genericArgsWithDefaults} = ${pascaleName}Record${genericArgs} & BaseSystemFields<${pascaleName}ExpandType>${type === "auth" ? " & AuthSystemFields" : ""}`;
+}
+function createExpandType(allRecords, targetRecord) {
+  const [directExpandTypes, directExpandConsts] = createDirectExpand(
+    allRecords,
+    targetRecord
+  );
+  const [indirectExpandTypes, indirectExpandConsts] = createIndirectExpand(
+    allRecords,
+    targetRecord
+  );
+  const expandTypes = [...directExpandTypes, ...indirectExpandTypes];
+  const expandConsts = [...directExpandConsts, ...indirectExpandConsts];
+  const hasExpandTypes = expandTypes.length > 0;
+  const pascaleName = toPascalCase(targetRecord.name);
+  const expandTypesString = `type ${pascaleName}ExpandType = {
+${hasExpandTypes ? expandTypes.join("\n") : "	// Doesn't have any relation"}
+}`;
+  const expandConstString = hasExpandTypes && `export const ${pascaleName}Expand = {
+  ${expandConsts.join(",\n")}
+}`;
+  return [expandTypesString, expandConstString].filter(Boolean).join("\n");
+}
+function createDirectExpand(allRecords, targetRecord) {
+  const expandTypes = [];
+  const expandConsts = [];
+  targetRecord.schema.filter(({ type }) => type === "relation").forEach(({ name, options: options2 }) => {
+    const expandedRecord = allRecords.find(
+      (record) => record.id === (options2 == null ? void 0 : options2.collectionId)
+    );
+    if (!expandedRecord) {
+      return;
+    }
+    const expandType = options2.maxSelect && options2.maxSelect > 1 ? `${toPascalCase(expandedRecord.name)}Response[]` : `${toPascalCase(expandedRecord.name)}Response`;
+    expandTypes.push(`	${name}: ${expandType}`);
+    const expandConst = `	${name}: "${name}"`;
+    expandConsts.push(expandConst);
+  });
+  return [expandTypes, expandConsts];
+}
+function createIndirectExpand(allRecords, targetRecord) {
+  const expandTypes = [];
+  const expandConsts = [];
+  allRecords.forEach((record) => {
+    record.schema.filter((field) => field.type === "relation").forEach((field) => {
+      var _a;
+      if (((_a = field.options) == null ? void 0 : _a.collectionId) !== targetRecord.id) {
+        return;
+      }
+      if (field.options.maxSelect && field.options.maxSelect > 1) {
+        return;
+      }
+      const expandKeyName = `${record.name}(${field.name})`;
+      expandTypes.push(
+        `	"${expandKeyName}": ${toPascalCase(record.name)}Response[]`
+      );
+      expandConsts.push(`	${record.name}: "${expandKeyName}"`);
+    });
+  });
+  return [expandTypes, expandConsts];
 }
 function createTypeField(collectionName, fieldSchema) {
   if (!(fieldSchema.type in pbSchemaTypescriptMap)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocketbase-typegen",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "commander": "^9.4.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const EXPORT_COMMENT = `/**
 */`
 export const RECORD_TYPE_COMMENT = `// Record types for each collection`
 export const RESPONSE_TYPE_COMMENT = `// Response types include system fields and match responses from the PocketBase API`
+export const EXPAND_TYPE_COMMENT = `// Expand types are used to define the expand object in the PocketBase API`
 export const DATE_STRING_TYPE_NAME = `IsoDateString`
 export const RECORD_ID_STRING_NAME = `RecordIdString`
 export const ALIAS_TYPE_DEFINITIONS = `// Alias types for improved usability
@@ -10,13 +11,13 @@ export type ${DATE_STRING_TYPE_NAME} = string
 export type ${RECORD_ID_STRING_NAME} = string`
 
 export const BASE_SYSTEM_FIELDS_DEFINITION = `// System fields
-export type BaseSystemFields = {
+export type BaseSystemFields<T> = {
 \tid: ${RECORD_ID_STRING_NAME}
 \tcreated: ${DATE_STRING_TYPE_NAME}
 \tupdated: ${DATE_STRING_TYPE_NAME}
 \tcollectionId: string
 \tcollectionName: Collections
-\texpand?: { [key: string]: any }
+\texpand?: T extends object ? T : never
 }`
 
 export const AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields = {
@@ -24,4 +25,4 @@ export const AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields = {
 \temailVisibility: boolean
 \tusername: string
 \tverified: boolean
-} & BaseSystemFields`
+}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export type CollectionRecord = {
 // Every field is optional
 export type RecordOptions = {
   maxSelect?: number | null
+  collectionId?: string | null
+  cascadeDelete?: boolean | null
   min?: number | null
   max?: number | null
   pattern?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { CollectionRecord, FieldSchema } from "./types"
+import { FieldSchema } from "./types"
 
 import { promises as fs } from "fs"
 
@@ -23,10 +23,6 @@ export function sanitizeFieldName(name: string) {
 export async function saveFile(outPath: string, typeString: string) {
   await fs.writeFile(outPath, typeString, "utf8")
   console.log(`Created typescript definitions at ${outPath}`)
-}
-
-export function getSystemFields(type: CollectionRecord["type"]) {
-  return type === "auth" ? "AuthSystemFields" : "BaseSystemFields"
 }
 
 export function getOptionEnumName(recordName: string, fieldName: string) {

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -18,13 +18,13 @@ export type IsoDateString = string
 export type RecordIdString = string
 
 // System fields
-export type BaseSystemFields = {
+export type BaseSystemFields\<T\> = {
 	id: RecordIdString
 	created: IsoDateString
 	updated: IsoDateString
 	collectionId: string
 	collectionName: Collections
-	expand?: { [key: string]: any }
+	expand?: T extends object ? T : never
 }
 
 export type AuthSystemFields = {
@@ -32,7 +32,7 @@ export type AuthSystemFields = {
 	emailVisibility: boolean
 	username: string
 	verified: boolean
-} & BaseSystemFields
+}
 
 // Record types for each collection
 
@@ -82,12 +82,42 @@ export type UsersRecord = {
 	avatar?: string
 }
 
+// Expand types are used to define the expand object in the PocketBase API
+type BaseExpandType = {
+	// Doesn't have any relation
+}
+type CustomAuthExpandType = {
+	// Doesn't have any relation
+}
+type EverythingExpandType = {
+	user_relation_field: UsersResponse
+	custom_relation_field: CustomAuthResponse[]
+	post_relation_field: PostsResponse
+}
+export const EverythingExpandKeys = {
+  	user_relation_field: "user_relation_field",
+	custom_relation_field: "custom_relation_field",
+	post_relation_field: "post_relation_field"
+}
+type PostsExpandType = {
+	"everything(post_relation_field)": EverythingResponse[]
+}
+export const PostsExpandKeys = {
+  	everything: "everything(post_relation_field)"
+}
+type UsersExpandType = {
+	"everything(user_relation_field)": EverythingResponse[]
+}
+export const UsersExpandKeys = {
+  	everything: "everything(user_relation_field)"
+}
+
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = BaseRecord & BaseSystemFields
-export type CustomAuthResponse = CustomAuthRecord & AuthSystemFields
-export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields
-export type PostsResponse = PostsRecord & BaseSystemFields
-export type UsersResponse = UsersRecord & AuthSystemFields
+export type BaseResponse = BaseRecord & BaseSystemFields\<BaseExpandType\>
+export type CustomAuthResponse = CustomAuthRecord & BaseSystemFields\<CustomAuthExpandType\> & AuthSystemFields
+export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields\<EverythingExpandType\>
+export type PostsResponse = PostsRecord & BaseSystemFields\<PostsExpandType\>
+export type UsersResponse = UsersRecord & BaseSystemFields\<UsersExpandType\> & AuthSystemFields
 
 export type CollectionRecords = {
 	base: BaseRecord

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -14,6 +14,62 @@ exports[`createCollectionRecord creates mapping of collection name to record typ
 }"
 `;
 
+exports[`createDirectExpand createDirectExpand create expand type for direct relation 1`] = `
+[
+  [
+    "	user: UsersResponse",
+  ],
+  [
+    "	user: "user"",
+  ],
+]
+`;
+
+exports[`createDirectExpand createDirectExpand create expand type for direct relation with two or more maxSelect 1`] = `
+[
+  [
+    "	authors: AuthorsResponse[]",
+  ],
+  [
+    "	authors: "authors"",
+  ],
+]
+`;
+
+exports[`createDirectExpand createDirectExpand not create expand type for unexist direct relation 1`] = `
+[
+  [],
+  [],
+]
+`;
+
+exports[`createDirectExpand createExpand create expand type 1`] = `
+"type UsersExpandType = {
+	"authors(user)": AuthorsResponse[]
+}
+export const UsersExpandKeys = {
+  	authors: "authors(user)"
+}"
+`;
+
+exports[`createDirectExpand createIndirectExpand create expand type for indirect relation 1`] = `
+[
+  [
+    "	"authors(user)": AuthorsResponse[]",
+  ],
+  [
+    "	authors: "authors(user)"",
+  ],
+]
+`;
+
+exports[`createDirectExpand createIndirectExpand not create expand type for indirect relation with two or more maxSelect 1`] = `
+[
+  [],
+  [],
+]
+`;
+
 exports[`createRecordType creates type definition for a record 1`] = `
 "export type BooksRecord = {
 	title?: string
@@ -26,7 +82,7 @@ exports[`createRecordType handles file fields with multiple files 1`] = `
 }"
 `;
 
-exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse = BooksRecord & BaseSystemFields"`;
+exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse = BooksRecord & BaseSystemFields<BooksExpandType>"`;
 
 exports[`createResponseType handles file fields with multiple files 1`] = `
 "export type BooksRecord = {
@@ -58,13 +114,13 @@ export type IsoDateString = string
 export type RecordIdString = string
 
 // System fields
-export type BaseSystemFields = {
+export type BaseSystemFields<T> = {
 	id: RecordIdString
 	created: IsoDateString
 	updated: IsoDateString
 	collectionId: string
 	collectionName: Collections
-	expand?: { [key: string]: any }
+	expand?: T extends object ? T : never
 }
 
 export type AuthSystemFields = {
@@ -72,7 +128,7 @@ export type AuthSystemFields = {
 	emailVisibility: boolean
 	username: string
 	verified: boolean
-} & BaseSystemFields
+}
 
 // Record types for each collection
 
@@ -80,8 +136,13 @@ export type BooksRecord = {
 	title?: string
 }
 
+// Expand types are used to define the expand object in the PocketBase API
+type BooksExpandType = {
+	// Doesn't have any relation
+}
+
 // Response types include system fields and match responses from the PocketBase API
-export type BooksResponse = BooksRecord & BaseSystemFields
+export type BooksResponse = BooksRecord & BaseSystemFields<BooksExpandType>
 
 export type CollectionRecords = {
 	books: BooksRecord

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -2,6 +2,9 @@ import { CollectionRecord, FieldSchema } from "../src/types"
 import {
   createCollectionEnum,
   createCollectionRecords,
+  createDirectExpand,
+  createExpandType,
+  createIndirectExpand,
   createRecordType,
   createResponseType,
   createSelectOptions,
@@ -386,5 +389,160 @@ describe("createSelectOptions", () => {
     ]
     const result = createSelectOptions(name, schema)
     expect(result).toMatchSnapshot()
+  })
+})
+
+describe("createDirectExpand", () => {
+  const collections: Array<CollectionRecord> = [
+    {
+      name: "users",
+      id: "123",
+      type: "auth",
+      system: false,
+      listRule: null,
+      viewRule: null,
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+      schema: [
+        {
+          name: "name",
+          type: "text",
+          required: false,
+          id: "xyz",
+          system: false,
+          unique: false,
+          options: {},
+        },
+      ],
+    },
+    {
+      name: "authors",
+      id: "456",
+      type: "base",
+      system: false,
+      listRule: null,
+      viewRule: null,
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+      schema: [
+        {
+          name: "user",
+          type: "relation",
+          required: false,
+          id: "xyz",
+          system: false,
+          unique: false,
+          options: {
+            collectionId: "123",
+            cascadeDelete: false,
+            maxSelect: 1,
+          },
+        },
+      ],
+    },
+    {
+      name: "books",
+      id: "789",
+      type: "base",
+      system: false,
+      listRule: null,
+      viewRule: null,
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+      schema: [
+        {
+          name: "title",
+          type: "text",
+          required: false,
+          id: "xyz",
+          system: false,
+          unique: false,
+          options: {},
+        },
+        {
+          name: "authors",
+          type: "relation",
+          required: false,
+          id: "xyz",
+          system: false,
+          unique: false,
+          options: {
+            collectionId: "456",
+            cascadeDelete: false,
+            maxSelect: 2,
+          },
+        },
+      ],
+    },
+    {
+      name: "publishers",
+      id: "abc",
+      type: "base",
+      system: false,
+      listRule: null,
+      viewRule: null,
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+      schema: [
+        {
+          name: "company",
+          type: "relation",
+          required: false,
+          id: "xyz",
+          system: false,
+          unique: false,
+          options: {
+            collectionId: "xxx",
+            cascadeDelete: false,
+            maxSelect: 1,
+          },
+        },
+      ],
+    },
+  ]
+
+  describe("createDirectExpand", () => {
+    it("create expand type for direct relation", () => {
+      const authorsCollection = collections[1]
+      const result = createDirectExpand(collections, authorsCollection)
+      expect(result).toMatchSnapshot()
+    })
+
+    it("create expand type for direct relation with two or more maxSelect", () => {
+      const booksCollection = collections[2]
+      const result = createDirectExpand(collections, booksCollection)
+      expect(result).toMatchSnapshot()
+    })
+
+    it("not create expand type for unexist direct relation", () => {
+      const publishersCollection = collections[3]
+      const result = createDirectExpand(collections, publishersCollection)
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe("createIndirectExpand", () => {
+    it("create expand type for indirect relation", () => {
+      const usersCollection = collections[0]
+      const result = createIndirectExpand(collections, usersCollection)
+      expect(result).toMatchSnapshot()
+    })
+
+    it("not create expand type for indirect relation with two or more maxSelect", () => {
+      const authorsCollection = collections[1]
+      const result = createIndirectExpand(collections, authorsCollection)
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe("createExpand", () => {
+    it("create expand type", () => {
+      const result = createExpandType(collections, collections[0])
+      expect(result).toMatchSnapshot()
+    })
   })
 })

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -15,13 +15,13 @@ export type IsoDateString = string
 export type RecordIdString = string
 
 // System fields
-export type BaseSystemFields = {
+export type BaseSystemFields<T> = {
 	id: RecordIdString
 	created: IsoDateString
 	updated: IsoDateString
 	collectionId: string
 	collectionName: Collections
-	expand?: { [key: string]: any }
+	expand?: T extends object ? T : never
 }
 
 export type AuthSystemFields = {
@@ -29,7 +29,7 @@ export type AuthSystemFields = {
 	emailVisibility: boolean
 	username: string
 	verified: boolean
-} & BaseSystemFields
+}
 
 // Record types for each collection
 
@@ -79,12 +79,42 @@ export type UsersRecord = {
 	avatar?: string
 }
 
+// Expand types are used to define the expand object in the PocketBase API
+type BaseExpandType = {
+	// Doesn't have any relation
+}
+type CustomAuthExpandType = {
+	// Doesn't have any relation
+}
+type EverythingExpandType = {
+	user_relation_field: UsersResponse
+	custom_relation_field: CustomAuthResponse[]
+	post_relation_field: PostsResponse
+}
+export const EverythingExpandKeys = {
+  	user_relation_field: "user_relation_field",
+	custom_relation_field: "custom_relation_field",
+	post_relation_field: "post_relation_field"
+}
+type PostsExpandType = {
+	"everything(post_relation_field)": EverythingResponse[]
+}
+export const PostsExpandKeys = {
+  	everything: "everything(post_relation_field)"
+}
+type UsersExpandType = {
+	"everything(user_relation_field)": EverythingResponse[]
+}
+export const UsersExpandKeys = {
+  	everything: "everything(user_relation_field)"
+}
+
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = BaseRecord & BaseSystemFields
-export type CustomAuthResponse = CustomAuthRecord & AuthSystemFields
-export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields
-export type PostsResponse = PostsRecord & BaseSystemFields
-export type UsersResponse = UsersRecord & AuthSystemFields
+export type BaseResponse = BaseRecord & BaseSystemFields<BaseExpandType>
+export type CustomAuthResponse = CustomAuthRecord & BaseSystemFields<CustomAuthExpandType> & AuthSystemFields
+export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields<EverythingExpandType>
+export type PostsResponse = PostsRecord & BaseSystemFields<PostsExpandType>
+export type UsersResponse = UsersRecord & BaseSystemFields<UsersExpandType> & AuthSystemFields
 
 export type CollectionRecords = {
 	base: BaseRecord

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,7 +1,6 @@
 import {
   getOptionEnumName,
   getOptionValues,
-  getSystemFields,
   sanitizeFieldName,
   toPascalCase,
 } from "../src/utils"
@@ -28,13 +27,6 @@ describe("sanitizeFieldName", () => {
   it("returns valid typescript fields", () => {
     expect(sanitizeFieldName("foo_bar")).toEqual("foo_bar")
     expect(sanitizeFieldName("4number")).toEqual('"4number"')
-  })
-})
-
-describe("getSystemFields", () => {
-  it("returns the system field type name for a given collection type", () => {
-    expect(getSystemFields("base")).toBe("BaseSystemFields")
-    expect(getSystemFields("auth")).toBe("AuthSystemFields")
   })
 })
 


### PR DESCRIPTION
Thank you for developing a good type generator library. I tried to add a function for supporting expanded types.
I changed it as below.
- Add function to generate "ExpandType" types and "ExpandKey" constants for direct/indirect relation
- Add a generics parameter to the "BaseSystemFields" type.
- Remove BaseSystemFields intersection type from AuthSystemFields and add it to UsersResponse

The generated code example is below.
``` 
type BooksExpandType = {
  author: AuthorsResponse;
}
export const BooksExpandKeys = {
  author: "author"
}

type AuthorExpandType =  {
  "books(author)": BooksResponse[];
}
export const AuthorExpandKeys = {
  books:  "books(author)"
}
```

You can use the generated code below.
```
const result = await pocketbase.collection(Collections.Books).getList<BooksResponse>(1, 50, {
  expand: BooksExpandKeys.author
});

const author = result.items[0].expand?.author // this is typed as AuthorResponse | undefined
```

Although I considered adding generics parameters to response types like "BooksResponse<AuthorExpandType | ...>", I decided not to do so. Even if we set the generics parameter to response types and specify the response data type, we end up having to do a null check for the response data because the data may be simply null. Therefore, I thought that it's more simple to list all possible expand types as optional types for users.