### PR TITLE
make all fields required in response types

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -258,7 +258,7 @@ function createResponseType(collectionSchemaEntry) {
   const genericArgsForRecord = getGenericArgStringForRecord(schema);
   const systemFields = getSystemFields(type);
   const expandArgString = canExpand(schema) ? `<T${EXPAND_GENERIC_NAME}>` : "";
-  return `export type ${pascaleName}Response${genericArgsWithDefaults} = ${pascaleName}Record${genericArgsForRecord} & ${systemFields}${expandArgString}`;
+  return `export type ${pascaleName}Response${genericArgsWithDefaults} = Required<${pascaleName}Record${genericArgsForRecord}> & ${systemFields}${expandArgString}`;
 }
 
 // src/cli.ts
@@ -284,7 +284,7 @@ async function main(options2) {
 import { program } from "commander";
 
 // package.json
-var version = "1.1.8";
+var version = "1.1.9";
 
 // src/index.ts
 program.name("Pocketbase Typegen").version(version).description(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Generate pocketbase record types from your database",
   "main": "dist/index.js",
   "bin": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -85,5 +85,5 @@ export function createResponseType(
   const systemFields = getSystemFields(type)
   const expandArgString = canExpand(schema) ? `<T${EXPAND_GENERIC_NAME}>` : ""
 
-  return `export type ${pascaleName}Response${genericArgsWithDefaults} = ${pascaleName}Record${genericArgsForRecord} & ${systemFields}${expandArgString}`
+  return `export type ${pascaleName}Response${genericArgsWithDefaults} = Required<${pascaleName}Record${genericArgsForRecord}> & ${systemFields}${expandArgString}`
 }

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -92,12 +92,12 @@ export type UsersRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = BaseRecord & BaseSystemFields
-export type CustomAuthResponse = CustomAuthRecord & AuthSystemFields
-export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields<Texpand>
-export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = MyViewRecord<Tjson_field> & BaseSystemFields<Texpand>
-export type PostsResponse = PostsRecord & BaseSystemFields
-export type UsersResponse = UsersRecord & AuthSystemFields
+export type BaseResponse = Required<BaseRecord> & BaseSystemFields
+export type CustomAuthResponse = Required<CustomAuthRecord> & AuthSystemFields
+export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = Required<EverythingRecord<Tanother_json_field, Tjson_field>> & BaseSystemFields<Texpand>
+export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = Required<MyViewRecord<Tjson_field>> & BaseSystemFields<Texpand>
+export type PostsResponse = Required<PostsRecord> & BaseSystemFields
+export type UsersResponse = Required<UsersRecord> & AuthSystemFields
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -12,7 +12,7 @@ exports[`createRecordType handles file fields with multiple files 1`] = `
 }"
 `;
 
-exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse = BooksRecord & BaseSystemFields"`;
+exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse = Required<BooksRecord> & BaseSystemFields"`;
 
 exports[`createResponseType handles file fields with multiple files 1`] = `
 "export type BooksRecord = {
@@ -58,7 +58,7 @@ export type BooksRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BooksResponse = BooksRecord & BaseSystemFields
+export type BooksResponse = Required<BooksRecord> & BaseSystemFields
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -89,12 +89,12 @@ export type UsersRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = BaseRecord & BaseSystemFields
-export type CustomAuthResponse = CustomAuthRecord & AuthSystemFields
-export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = EverythingRecord<Tanother_json_field, Tjson_field> & BaseSystemFields<Texpand>
-export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = MyViewRecord<Tjson_field> & BaseSystemFields<Texpand>
-export type PostsResponse = PostsRecord & BaseSystemFields
-export type UsersResponse = UsersRecord & AuthSystemFields
+export type BaseResponse = Required<BaseRecord> & BaseSystemFields
+export type CustomAuthResponse = Required<CustomAuthRecord> & AuthSystemFields
+export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = Required<EverythingRecord<Tanother_json_field, Tjson_field>> & BaseSystemFields<Texpand>
+export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = Required<MyViewRecord<Tjson_field>> & BaseSystemFields<Texpand>
+export type PostsResponse = Required<PostsRecord> & BaseSystemFields
+export type UsersResponse = Required<UsersRecord> & AuthSystemFields
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 


### PR DESCRIPTION
This is because pocketbase uses default values for optional fields in API responses.

The original Record types remain the same (with optional fields) and can be correctly typed for creating new records.

fixes https://github.com/patmood/pocketbase-typegen/issues/58