### PR TITLE
handle empty collections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to run e2e integration tests against a test PocketBase server
 FROM node:16-alpine3.16
 
-ARG POCKETBASE_VERSION=0.13.0
+ARG POCKETBASE_VERSION=0.15.0
 
 WORKDIR /app/output/
 WORKDIR /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to run e2e integration tests against a test PocketBase server
 FROM node:16-alpine3.16
 
-ARG POCKETBASE_VERSION=0.15.0
+ARG POCKETBASE_VERSION=0.13.0
 
 WORKDIR /app/output/
 WORKDIR /app/
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${POCKETBASE_VERSION}/pocketbase_${POCKETBASE_VERSION}_linux_amd64.zip /tmp/pocketbase.zip
 RUN unzip /tmp/pocketbase.zip -d /app/
 
+# Install dependencies for the pocketbase-typegen package
 COPY package.json package-lock.json ./
 RUN npm ci
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -245,9 +245,9 @@ function createRecordType(name, schema) {
     includeExpand: false
   });
   const fields = schema.map((fieldSchema) => createTypeField(name, fieldSchema)).join("\n");
-  return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = {
+  return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = ${fields ? `{
 ${fields}
-}`;
+}` : "never"}`;
 }
 function createResponseType(collectionSchemaEntry) {
   const { name, schema, type } = collectionSchemaEntry;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -68,9 +68,13 @@ export function createRecordType(
     .map((fieldSchema: FieldSchema) => createTypeField(name, fieldSchema))
     .join("\n")
 
-  return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = {
+  return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = ${
+    fields
+      ? `{
 ${fields}
 }`
+      : "never"
+  }`
 }
 
 export function createResponseType(

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -11,4 +11,3 @@ node ./dist/index.js --url http://0.0.0.0:8090 --email test@test.com --password 
 node ./dist/index.js --db pb_data/data.db --out output/pocketbase-types-db.ts
 
 node integration.js
-echo "Integration tests pass"

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -11,3 +11,4 @@ node ./dist/index.js --url http://0.0.0.0:8090 --email test@test.com --password 
 node ./dist/index.js --db pb_data/data.db --out output/pocketbase-types-db.ts
 
 node integration.js
+echo "Integration tests pass"


### PR DESCRIPTION
Use `never` instead of `{}` for empty collections. This is mostly relevant for auth collections which come with standard fields.

fixes https://github.com/patmood/pocketbase-typegen/issues/56