### PR TITLE
always include generic argument for expand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Generate pocketbase record types from your database",
   "main": "dist/index.js",
   "bin": {

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -25,15 +25,10 @@ export function getGenericArgStringWithDefault(
 ): string {
   const argList = getGenericArgList(schema)
 
-  if (opts.includeExpand && canExpand(schema)) {
+  if (opts.includeExpand) {
     argList.push(fieldNameToGeneric(EXPAND_GENERIC_NAME))
   }
 
   if (argList.length === 0) return ""
   return `<${argList.map((name) => `${name} = unknown`).join(", ")}>`
-}
-
-// Does the collection have relation fields that can be expanded
-export function canExpand(schema: FieldSchema[]) {
-  return !!schema.find((field) => field.type === "relation")
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -10,16 +10,15 @@ import {
 } from "./constants"
 import { CollectionRecord, FieldSchema } from "./types"
 import {
-  canExpand,
-  getGenericArgStringForRecord,
-  getGenericArgStringWithDefault,
-} from "./generics"
-import {
   createCollectionEnum,
   createCollectionRecords,
   createCollectionResponses,
 } from "./collections"
 import { createSelectOptions, createTypeField } from "./fields"
+import {
+  getGenericArgStringForRecord,
+  getGenericArgStringWithDefault,
+} from "./generics"
 import { getSystemFields, toPascalCase } from "./utils"
 
 export function generate(results: Array<CollectionRecord>): string {
@@ -87,7 +86,7 @@ export function createResponseType(
   })
   const genericArgsForRecord = getGenericArgStringForRecord(schema)
   const systemFields = getSystemFields(type)
-  const expandArgString = canExpand(schema) ? `<T${EXPAND_GENERIC_NAME}>` : ""
+  const expandArgString = `<T${EXPAND_GENERIC_NAME}>`
 
   return `export type ${pascaleName}Response${genericArgsWithDefaults} = Required<${pascaleName}Record${genericArgsForRecord}> & ${systemFields}${expandArgString}`
 }

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -92,12 +92,12 @@ export type UsersRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = Required<BaseRecord> & BaseSystemFields
-export type CustomAuthResponse = Required<CustomAuthRecord> & AuthSystemFields
+export type BaseResponse<Texpand = unknown> = Required<BaseRecord> & BaseSystemFields<Texpand>
+export type CustomAuthResponse<Texpand = unknown> = Required<CustomAuthRecord> & AuthSystemFields<Texpand>
 export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = Required<EverythingRecord<Tanother_json_field, Tjson_field>> & BaseSystemFields<Texpand>
 export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = Required<MyViewRecord<Tjson_field>> & BaseSystemFields<Texpand>
-export type PostsResponse = Required<PostsRecord> & BaseSystemFields
-export type UsersResponse = Required<UsersRecord> & AuthSystemFields
+export type PostsResponse<Texpand = unknown> = Required<PostsRecord> & BaseSystemFields<Texpand>
+export type UsersResponse<Texpand = unknown> = Required<UsersRecord> & AuthSystemFields<Texpand>
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -12,7 +12,7 @@ exports[`createRecordType handles file fields with multiple files 1`] = `
 }"
 `;
 
-exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse = Required<BooksRecord> & BaseSystemFields"`;
+exports[`createResponseType creates type definition for a response 1`] = `"export type BooksResponse<Texpand = unknown> = Required<BooksRecord> & BaseSystemFields<Texpand>"`;
 
 exports[`createResponseType handles file fields with multiple files 1`] = `
 "export type BooksRecord = {
@@ -58,7 +58,7 @@ export type BooksRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BooksResponse = Required<BooksRecord> & BaseSystemFields
+export type BooksResponse<Texpand = unknown> = Required<BooksRecord> & BaseSystemFields<Texpand>
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 

--- a/test/generics.test.ts
+++ b/test/generics.test.ts
@@ -1,5 +1,4 @@
 import {
-  canExpand,
   getGenericArgList,
   getGenericArgStringForRecord,
   getGenericArgStringWithDefault,
@@ -125,14 +124,5 @@ describe("getGenericArgStringForRecord", () => {
     expect(
       getGenericArgStringForRecord([textField, jsonField2, jsonField1])
     ).toEqual("<Tdata1, Tdata2>")
-  })
-})
-
-describe("canExpand", () => {
-  it("detects collections that can be expanded", () => {
-    expect(canExpand([textField, jsonField1, expandField])).toEqual(true)
-  })
-  it("detects collections that cannot be expanded", () => {
-    expect(canExpand([textField, jsonField1])).toEqual(false)
   })
 })

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -89,12 +89,12 @@ export type UsersRecord = {
 }
 
 // Response types include system fields and match responses from the PocketBase API
-export type BaseResponse = Required<BaseRecord> & BaseSystemFields
-export type CustomAuthResponse = Required<CustomAuthRecord> & AuthSystemFields
+export type BaseResponse<Texpand = unknown> = Required<BaseRecord> & BaseSystemFields<Texpand>
+export type CustomAuthResponse<Texpand = unknown> = Required<CustomAuthRecord> & AuthSystemFields<Texpand>
 export type EverythingResponse<Tanother_json_field = unknown, Tjson_field = unknown, Texpand = unknown> = Required<EverythingRecord<Tanother_json_field, Tjson_field>> & BaseSystemFields<Texpand>
 export type MyViewResponse<Tjson_field = unknown, Texpand = unknown> = Required<MyViewRecord<Tjson_field>> & BaseSystemFields<Texpand>
-export type PostsResponse = Required<PostsRecord> & BaseSystemFields
-export type UsersResponse = Required<UsersRecord> & AuthSystemFields
+export type PostsResponse<Texpand = unknown> = Required<PostsRecord> & BaseSystemFields<Texpand>
+export type UsersResponse<Texpand = unknown> = Required<UsersRecord> & AuthSystemFields<Texpand>
 
 // Types containing all Records and Responses, useful for creating typing helper functions
 


### PR DESCRIPTION
Indirect expansions mean all records could potentially have the expand field, so it's useful to always include it.

fixes https://github.com/patmood/pocketbase-typegen/issues/66