### PR TITLE
Add option to use environment variables as url, email and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Options:
   -e, --email <char>     email for an admin pocketbase user. Use this with the --url option
   -p, --password <char>  password for an admin pocketbase user. Use this with the --url option
   -o, --out <char>       path to save the typescript output file (default: "pocketbase-types.ts")
+  -e, --env              flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file
   -h, --help             display help for command
 ```
 
@@ -39,6 +40,18 @@ JSON example (export JSON schema from the pocketbase admin dashboard):
 URL example:
 
 `npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject.com --password 'secr3tp@ssword!'`
+
+ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file)
+
+`npx pocketbase-typegen --env`
+
+.env:
+
+```
+PB_TYPEGEN_URL=https://myproject.pockethost.io
+PB_TYPEGEN_EMAIL=admin@myproject.com
+PB_TYPEGEN_PASSWORD=secr3tp@ssword!
+```
 
 Add it to your projects `package.json`:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ URL example:
 
 `npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject.com --password 'secr3tp@ssword!'`
 
-ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file)
+ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file):
 
 `npx pocketbase-typegen --env`
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -316,6 +316,9 @@ program.name("Pocketbase Typegen").version(version).description(
   "-o, --out <char>",
   "path to save the typescript output file",
   "pocketbase-types.ts"
+).option(
+  "-e, --env",
+  "flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file"
 );
 program.parse(process.argv);
 var options = program.opts();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// src/cli.ts
+import "dotenv/config";
+
 // src/schema.ts
 import FormData from "form-data";
 import fetch from "cross-fetch";
@@ -267,6 +270,17 @@ async function main(options2) {
     schema = await fromJSON(options2.json);
   } else if (options2.url) {
     schema = await fromURL(options2.url, options2.email, options2.password);
+  } else if (options2.env) {
+    if (!process.env.PB_TYPEGEN_URL || !process.env.PB_TYPEGEN_EMAIL || !process.env.PB_TYPEGEN_PASSWORD) {
+      return console.error(
+        "Missing environment variables. Check options: pocketbase-typegen --help"
+      );
+    }
+    schema = await fromURL(
+      process.env.PB_TYPEGEN_URL,
+      process.env.PB_TYPEGEN_EMAIL,
+      process.env.PB_TYPEGEN_PASSWORD
+    );
   } else {
     return console.error(
       "Missing schema path. Check options: pocketbase-typegen --help"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocketbase-typegen",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "ISC",
       "dependencies": {
         "commander": "^9.4.1",
         "cross-fetch": "^3.1.5",
+        "dotenv": "^16.3.1",
         "form-data": "^4.0.0",
         "sqlite": "^4.1.2",
         "sqlite3": "^5.1.4"
@@ -2411,6 +2412,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8060,6 +8072,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.281",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "commander": "^9.4.1",
     "cross-fetch": "^3.1.5",
+    "dotenv": "^16.3.1",
     "form-data": "^4.0.0",
     "sqlite": "^4.1.2",
     "sqlite3": "^5.1.4"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,8 @@
+import 'dotenv/config'
+
 import type { CollectionRecord, Options } from "./types"
 import { fromDatabase, fromJSON, fromURL } from "./schema"
+
 
 import { generate } from "./lib"
 import { saveFile } from "./utils"
@@ -12,6 +15,17 @@ export async function main(options: Options) {
     schema = await fromJSON(options.json)
   } else if (options.url) {
     schema = await fromURL(options.url, options.email, options.password)
+  } else if (options.env) {
+    if (!process.env.PB_TYPEGEN_URL || !process.env.PB_TYPEGEN_EMAIL || !process.env.PB_TYPEGEN_PASSWORD) {
+      return console.error(
+        "Missing environment variables. Check options: pocketbase-typegen --help"
+      )
+    }
+    schema = await fromURL(
+      process.env.PB_TYPEGEN_URL,
+      process.env.PB_TYPEGEN_EMAIL,
+      process.env.PB_TYPEGEN_PASSWORD
+    )
   } else {
     return console.error(
       "Missing schema path. Check options: pocketbase-typegen --help"

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ program
     "path to save the typescript output file",
     "pocketbase-types.ts"
   )
+  .option(
+    "-e, --env",
+    "flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file"
+  )
 
 program.parse(process.argv)
 const options = program.opts<Options>()

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Options = {
   json?: string
   email?: string
   password?: string
+  env?: boolean
 }
 
 export type FieldSchema = {

--- a/test/integration/.env
+++ b/test/integration/.env
@@ -1,0 +1,3 @@
+PB_TYPEGEN_URL=http://0.0.0.0:8090
+PB_TYPEGEN_EMAIL=test@test.com
+PB_TYPEGEN_PASSWORD=testpassword

--- a/test/integration/integration.js
+++ b/test/integration/integration.js
@@ -13,6 +13,13 @@ async function testCreateFromUrl() {
   assert.equal(typesFromUrl, controlTypes)
 }
 
+async function testCreateFromEnv() {
+  const typesFromEnv = await fs.readFile("output/pocketbase-types-env.ts", {
+    encoding: "utf8",
+  })
+  assert.equal(typesFromEnv, controlTypes)
+}
+
 async function testCreateFromDb() {
   const typesFromDb = await fs.readFile("output/pocketbase-types-db.ts", {
     encoding: "utf8",
@@ -22,3 +29,4 @@ async function testCreateFromDb() {
 
 await testCreateFromUrl()
 await testCreateFromDb()
+await testCreateFromEnv()

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -9,6 +9,7 @@ while ! nc -z localhost 8090 </dev/null; do sleep 1; done
 
 node ./dist/index.js --url http://0.0.0.0:8090 --email test@test.com --password testpassword --out output/pocketbase-types-url.ts
 node ./dist/index.js --db pb_data/data.db --out output/pocketbase-types-db.ts
+node ./dist/index.js --env --out output/pocketbase-types-env.ts
 
 node integration.js
 exit_status=$?


### PR DESCRIPTION
Thank you for this useful tool.

I didn't want to type in url, email and password each time i wanted to synchronize the schema so i created an option to use environment variables as url, email and password.

To use it you need to have `PB_TYPEGEN_URL`, `PB_TYPEGEN_EMAIL` and `PB_TYPEGEN_PASSWORD` set in your .env file, and add the `--env` flag

Also I updated the readme file and integration testing. Though I couldn't figure out a way to fix the code coverage for my changes.