### PR TITLE
Make --env accept custom path to .env file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config'
+import dotenv from "dotenv"
 
 import type { CollectionRecord, Options } from "./types"
 import { fromDatabase, fromJSON, fromURL } from "./schema"
@@ -16,6 +16,10 @@ export async function main(options: Options) {
   } else if (options.url) {
     schema = await fromURL(options.url, options.email, options.password)
   } else if (options.env) {
+    let path: string = typeof options.env === "string"
+      ? options.env
+      : ".env"
+    dotenv.config({ path: path, override: true })
     if (!process.env.PB_TYPEGEN_URL || !process.env.PB_TYPEGEN_EMAIL || !process.env.PB_TYPEGEN_PASSWORD) {
       return console.error(
         "Missing environment variables. Check options: pocketbase-typegen --help"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ export async function main(options: Options) {
     const path: string = typeof options.env === "string"
       ? options.env
       : ".env"
-    dotenv.config({ path: path, override: true })
+    dotenv.config({ path: path })
     if (!process.env.PB_TYPEGEN_URL || !process.env.PB_TYPEGEN_EMAIL || !process.env.PB_TYPEGEN_PASSWORD) {
       return console.error(
         "Missing environment variables. Check options: pocketbase-typegen --help"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ export async function main(options: Options) {
   } else if (options.url) {
     schema = await fromURL(options.url, options.email, options.password)
   } else if (options.env) {
-    let path: string = typeof options.env === "string"
+    const path: string = typeof options.env === "string"
       ? options.env
       : ".env"
     dotenv.config({ path: path, override: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ program
   )
   .option(
     "-e, --env [path]",
-    "flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file"
+    "flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file"
   )
 
 program.parse(process.argv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ program
     "pocketbase-types.ts"
   )
   .option(
-    "-e, --env",
+    "-e, --env [path]",
     "flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file"
   )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type Options = {
   json?: string
   email?: string
   password?: string
-  env?: boolean
+  env?: boolean | string
 }
 
 export type FieldSchema = {


### PR DESCRIPTION
To make --env option accept an optional path.

For our setup the .env file is included in git and contains no sensitive information