### PR TITLE
prefix numeric enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Generate pocketbase record types from your database",
   "main": "dist/index.js",
   "bin": {

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -87,10 +87,19 @@ export function createSelectOptions(
     .map(
       (field) => `export enum ${getOptionEnumName(recordName, field.name)} {
 ${getOptionValues(field)
-  .map((val) => `\t"${val}" = "${val}",`)
+  .map((val) => `\t"${getSelectOptionEnumName(val)}" = "${val}",`)
   .join("\n")}
 }\n`
     )
     .join("\n")
   return typestring
+}
+
+export function getSelectOptionEnumName(val: string) {
+  if (!isNaN(Number(val))) {
+    // The value is a number, which cannot be used as an enum name
+    return `E${val}`
+  } else {
+    return val
+  }
 }

--- a/test/fields.test.ts
+++ b/test/fields.test.ts
@@ -1,4 +1,8 @@
-import { createSelectOptions, createTypeField } from "../src/fields"
+import {
+  createSelectOptions,
+  createTypeField,
+  getSelectOptionEnumName,
+} from "../src/fields"
 
 import { FieldSchema } from "../src/types"
 
@@ -263,5 +267,18 @@ describe("createSelectOptions", () => {
     ]
     const result = createSelectOptions(name, schema)
     expect(result).toMatchSnapshot()
+  })
+})
+
+describe("getSelectOptionEnumName", () => {
+  it("uses the select option value as the enum name", () => {
+    expect(getSelectOptionEnumName("hello")).toEqual("hello")
+    expect(getSelectOptionEnumName("2022X")).toEqual("2022X")
+  })
+
+  it("prefixes the enum name when the value is a number", () => {
+    expect(getSelectOptionEnumName("2022")).toEqual("E2022")
+    expect(getSelectOptionEnumName("0")).toEqual("E0")
+    expect(getSelectOptionEnumName("0123")).toEqual("E0123")
   })
 })


### PR DESCRIPTION
You can't have a typescript enum name that is a number (see https://github.com/Microsoft/TypeScript/issues/19438). Since the value is used as the name by default, numeric values need to be prefixed.

I've used an "E" as the prefix.

This wouldn't be necessary if string unions were used instead of enums, but that's the path we took. In future an option could be passed to choose the select field type.

fixes https://github.com/patmood/pocketbase-typegen/issues/74