### PR TITLE
Add automatic schema synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Options:
   -e, --env              flag to use environment variables for configuration, add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file
   -w, --watch            watch for changes in the database and automatically regenerate types, does not work with --json
   -i, --interval <int>   interval in milliseconds to check for changes (default: 5000)
-  -h, --hook-url <char>  custom hook url for checking changes, should return json with timestamp of last change, use with --watch
+  --hook <char>  custom hook url for checking changes, should return json with timestamp of last change, use with --watch
   -h, --help             display help for command
 ```
 
@@ -57,41 +57,52 @@ PB_TYPEGEN_PASSWORD=secr3tp@ssword!
 ```
 
 Watch mode example:
+
 `npx pocketbase-typegen --db ./pb_data/data.db --watch`
+
 `npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject --password 'secr3tp@ssword!' --watch`
+
 `npx pocketbase-typegen --env --watch`
+
 Optional flags:
-  - `--interval` - interval in milliseconds to check for changes (default: 5000)
-  - `--hook` - custom hook url for checking changes, should return json with timestamp of last change
-example hook js code (works after v0.17.0, add to pb_hooks directory):
+
+- `--interval` - interval in milliseconds to check for changes (default: 5000)
+- `--hook` - custom hook url for checking changes, should return json with timestamp of last change
+
+example hook javascript code (works on pocketbase version ^0.17.0, add to pb_hooks directory):
+
+watch.pb.js
+
 ```javascript
 routerAdd("GET", "/schema/last-update", (c) => {
-	try {
-		const config = require(`./pb_hooks/config.js`)
-    		return c.json(200, { "timestamp": config.lastTimestamp })
-	} catch (err) {
-		return c.json(200, {"message": err.message})
-	}
+  try {
+    const config = require(`./pb_hooks/config.js`)
+    return c.json(200, { timestamp: config.lastTimestamp })
+  } catch (err) {
+    return c.json(200, { message: err.message })
+  }
 })
 
 // Hooks for updating lastTimestamp
 onModelAfterCreate((_) => {
-  	const config = require(`./pb_hooks/config.js`)
-	config.lastTimestamp = Date.now()
+  const config = require(`./pb_hooks/config.js`)
+  config.lastTimestamp = Date.now()
 })
 onModelAfterUpdate((_) => {
-	const config = require(`./pb_hooks/config.js`)
-	config.lastTimestamp = Date.now()
+  const config = require(`./pb_hooks/config.js`)
+  config.lastTimestamp = Date.now()
 })
 onModelAfterDelete((_) => {
-	const config = require(`./pb_hooks/config.js`)
-	config.lastTimestamp = Date.now()
+  const config = require(`./pb_hooks/config.js`)
+  config.lastTimestamp = Date.now()
 })
 ```
+
 config.js:
+
 ```javascript
 module.exports = {
-  lastTimestamp: 0
+  lastTimestamp: 0,
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,67 @@ program
     "-e, --env [path]",
     "flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file"
   )
+  .option(
+    "-w, --watch",
+    "watch for changes in the database and automatically regenerate types, does not work with --json"
+  )
+  .option(
+    "-i, --interval <number>",
+    "interval in ms to check for changes in watch mode, defaults to 5000"
+  )
+  .option(
+    "--hook <char>",
+    "custom hook url for checking changes, should return json with timestamp of last change, use with --watch"
+  )
 
 program.parse(process.argv)
 const options = program.opts<Options>()
+// intitial watch mode check
+if (options.watch) {
+  if (!options.interval) {
+    options.interval = 5000
+  }
+  if (options.hook == "") {
+    console.error("Hook url must not be empty when using --watch")
+    process.exit(1)
+  }
+  if (options.json) {
+    console.error(
+      "Cannot use --watch with --json. Check options: pocketbase-typegen --help"
+    )
+    process.exit(1)
+  }
+}
 main(options)
+if (options.watch) {
+  console.log("[pocketbase-typegen] watching for changes...")
+  let lastTime = Date.now()
+  setInterval(async () => {
+    if (!options.hook) {
+      main(options)
+      return console.log("[pocketbase-typegen] synchronizing changes")
+    }
+    try {
+      const res = await fetch(options.hook, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      if (res.status !== 200) {
+        return console.log(
+          "[pocketbase-typegen] error synchronizing changes, skipping"
+        )
+      }
+      const data = await res.json()
+      if (data.timestamp > lastTime) {
+        lastTime = data.timestamp
+        main(options)
+        console.log("[pocketbase-typegen] synchronizing changes")
+      }
+    } catch (err) {
+      console.log("[pocketbase-typegen] error synchronizing changes, skipping")
+      console.error(err)
+    }
+  }, options.interval)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export type Options = {
   email?: string
   password?: string
   env?: boolean | string
+  watch?: boolean
+  interval?: number
+  hook?: string
 }
 
 export type FieldSchema = {


### PR DESCRIPTION
Hello, i have implemented a feature to automatically check and synchronize the definition file to newest pocketbase schema.

This PR adds 3 flags:
 - ``--watch`` - enables this feature
 - ``--interval`` - interval in ms at which it's checking/synchronizing (defaults to 5000ms)
 - ``--hook`` - url to check whether there are new changes in the schema, if it's not defined it blindly synchronizes it even if it's the same.

Also i updated the README on how to properly setup it
 
It's using hooks in js which was added in pocketbase v0.17.0 to save the timestamp when changing the schema and creates a custom route to access it, then locally it periodically compares the timestamps and reruns the main function. As of right now it's not saving the timestamps between restarts but it should be fine because it's synchronizing when starting the watch mode. I couldn't figure out a way how to properly add integration testing.

Feel free to close this pr if you think the feature is not needed and/or poorly implemented.