### PR TITLE
sort fields alphabetically

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -251,7 +251,7 @@ function createRecordType(name, schema) {
   const genericArgs = getGenericArgStringWithDefault(schema, {
     includeExpand: false
   });
-  const fields = schema.map((fieldSchema) => createTypeField(name, fieldSchema)).join("\n");
+  const fields = schema.map((fieldSchema) => createTypeField(name, fieldSchema)).sort().join("\n");
   return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = ${fields ? `{
 ${fields}
 }` : "never"}`;
@@ -304,7 +304,7 @@ async function main(options2) {
 import { program } from "commander";
 
 // package.json
-var version = "1.1.12";
+var version = "1.1.13";
 
 // src/index.ts
 program.name("Pocketbase Typegen").version(version).description(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Generate pocketbase record types from your database",
   "main": "dist/index.js",
   "bin": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -65,6 +65,7 @@ export function createRecordType(
   })
   const fields = schema
     .map((fieldSchema: FieldSchema) => createTypeField(name, fieldSchema))
+    .sort()
     .join("\n")
 
   return `${selectOptionEnums}export type ${typeName}Record${genericArgs} = ${

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -55,40 +55,40 @@ export enum EverythingSelectFieldOptions {
 	"sy?mb@!$" = "sy?mb@!$",
 }
 export type EverythingRecord<Tanother_json_field = unknown, Tjson_field = unknown> = {
-	text_field?: string
-	number_field?: number
-	bool_field?: boolean
-	email_field?: string
-	url_field?: string
-	date_field?: IsoDateString
-	select_field?: EverythingSelectFieldOptions
-	json_field?: null | Tjson_field
 	another_json_field?: null | Tanother_json_field
-	file_field?: string
-	three_files_field?: string[]
-	user_relation_field?: RecordIdString
+	bool_field?: boolean
 	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: string
+	json_field?: null | Tjson_field
+	number_field?: number
 	post_relation_field?: RecordIdString
-	select_field_no_values?: string
 	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: string[]
+	url_field?: string
+	user_relation_field?: RecordIdString
 }
 
 export type MyViewRecord<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
 	post_relation_field?: RecordIdString
 	text_field?: string
-	json_field?: null | Tjson_field
 }
 
 export type PostsRecord = {
-	field?: string
-	nonempty_field: string
-	nonempty_bool: boolean
 	field1?: number
+	field?: string
+	nonempty_bool: boolean
+	nonempty_field: string
 }
 
 export type UsersRecord = {
-	name?: string
 	avatar?: string
+	name?: string
 }
 
 // Response types include system fields and match responses from the PocketBase API

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -66,6 +66,36 @@ describe("createRecordType", () => {
     const result = createRecordType(name, schema)
     expect(result).toMatchSnapshot()
   })
+
+  it("sorts fields alphabetically", () => {
+    const name = "books"
+    const schema: FieldSchema[] = [
+      {
+        id: "1",
+        name: "banana",
+        options: {},
+        required: false,
+        system: false,
+        type: "text",
+        unique: false,
+      },
+      {
+        id: "1",
+        name: "apple",
+        options: {},
+        required: false,
+        system: false,
+        type: "text",
+        unique: false,
+      },
+    ]
+    const result = createRecordType(name, schema)
+    const aIndex = result.indexOf("apple")
+    const bIndex = result.indexOf("banana")
+    expect(aIndex).toBeGreaterThan(0)
+    expect(bIndex).toBeGreaterThan(0)
+    expect(aIndex).toBeLessThan(bIndex)
+  })
 })
 
 describe("createResponseType", () => {

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -52,40 +52,40 @@ export enum EverythingSelectFieldOptions {
 	"sy?mb@!$" = "sy?mb@!$",
 }
 export type EverythingRecord<Tanother_json_field = unknown, Tjson_field = unknown> = {
-	text_field?: string
-	number_field?: number
-	bool_field?: boolean
-	email_field?: string
-	url_field?: string
-	date_field?: IsoDateString
-	select_field?: EverythingSelectFieldOptions
-	json_field?: null | Tjson_field
 	another_json_field?: null | Tanother_json_field
-	file_field?: string
-	three_files_field?: string[]
-	user_relation_field?: RecordIdString
+	bool_field?: boolean
 	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: string
+	json_field?: null | Tjson_field
+	number_field?: number
 	post_relation_field?: RecordIdString
-	select_field_no_values?: string
 	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: string[]
+	url_field?: string
+	user_relation_field?: RecordIdString
 }
 
 export type MyViewRecord<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
 	post_relation_field?: RecordIdString
 	text_field?: string
-	json_field?: null | Tjson_field
 }
 
 export type PostsRecord = {
-	field?: string
-	nonempty_field: string
-	nonempty_bool: boolean
 	field1?: number
+	field?: string
+	nonempty_bool: boolean
+	nonempty_field: string
 }
 
 export type UsersRecord = {
-	name?: string
 	avatar?: string
+	name?: string
 }
 
 // Response types include system fields and match responses from the PocketBase API


### PR DESCRIPTION
Sort the fields of each record to keep the generated types stable.

Fields can be re-ordered in the admin UI and saved locally in the schema, but if multiple people are working on a project there is no way to replicate these changes across local environments. Sorting the keys will prevent constant changes.

fixes https://github.com/patmood/pocketbase-typegen/issues/77