### PR TITLE
Update Auth Endpoints For v0.23 RC

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,7 @@ async function fromURL(url, email = "", password = "") {
   formData.append("password", password);
   let collections = [];
   try {
-    const { token } = await fetch(`${url}/api/admins/auth-with-password`, {
+    const { token } = await fetch(`${url}/api/collections/_superusers/auth-with-password`, {
       body: formData,
       method: "post"
     }).then((res) => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -35,7 +35,7 @@ export async function fromURL(
   let collections: Array<CollectionRecord> = []
   try {
     // Login
-    const { token } = await fetch(`${url}/api/admins/auth-with-password`, {
+    const { token } = await fetch(`${url}/api/collections/_superusers/auth-with-password`, {
       // @ts-ignore
       body: formData,
       method: "post",


### PR DESCRIPTION
I'm currently testing PocketBase v0.23 RC and noticed that the authentication endpoints for admin auth have been updated to use the new _superusers collection, which makes this package incompatible with the new version. The changes to the endpoints were the only adjustments needed, and I was able to successfully pull my schema after making these updates.

**Breaking Changes**
Since these are breaking changes, I was hoping you might consider adding them to a beta branch, so that we can continue using the package while developing for the RC version of PocketBase until the official release.

Thanks!