### PR TITLE
Draft: Fix cli shorthand conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Options:
   -d, --db <char>        path to the pocketbase SQLite database
   -j, --json <char>      path to JSON schema exported from pocketbase admin UI
   -u, --url <char>       URL to your hosted pocketbase instance. When using this options you must also provide email and password options.
-  -e, --email <char>     email for an admin pocketbase user. Use this with the --url option
+  --email <char>     email for an admin pocketbase user. Use this with the --url option
   -p, --password <char>  password for an admin pocketbase user. Use this with the --url option
   -o, --out <char>       path to save the typescript output file (default: "pocketbase-types.ts")
   --no-sdk               remove the pocketbase package dependency. A typed version of the SDK will not be generated.
-  -e, --env [path]       flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file
+  --env [path]       flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file
   -h, --help             display help for command
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -331,7 +331,7 @@ program.name("Pocketbase Typegen").version(version).description(
   "-u, --url <char>",
   "URL to your hosted pocketbase instance. When using this options you must also provide email and password options."
 ).option(
-  "-e, --email <char>",
+  "--email <char>",
   "email for an admin pocketbase user. Use this with the --url option"
 ).option(
   "-p, --password <char>",
@@ -344,7 +344,7 @@ program.name("Pocketbase Typegen").version(version).description(
   "--no-sdk",
   "remove the pocketbase package dependency. A typed version of the SDK will not be generated."
 ).option(
-  "-e, --env [path]",
+  "--env [path]",
   "flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file"
 );
 program.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ program
     "URL to your hosted pocketbase instance. When using this options you must also provide email and password options."
   )
   .option(
-    "-e, --email <char>",
+    "--email <char>",
     "email for an admin pocketbase user. Use this with the --url option"
   )
   .option(
@@ -38,7 +38,7 @@ program
     "remove the pocketbase package dependency. A typed version of the SDK will not be generated."
   )
   .option(
-    "-e, --env [path]",
+    "--env [path]",
     "flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file"
   )
 


### PR DESCRIPTION
## Description

Remove the short flags for `--env` and `--email`.

- docs: updated the readme
- feat: removed `-e` flag from cli

## Remark

Merge after #103 

## Issue

fixes #95 