### PR TITLE
Add generation types for Create and Update requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -375,21 +375,27 @@ ${fields}
 function createCreateType(collectionSchemaEntry) {
   const { name, fields, type } = collectionSchemaEntry;
   const typeName = toPascalCase(name);
+  const genericArgs = getGenericArgStringWithDefault(fields, {
+    includeExpand: false
+  });
   const systemFields = getSystemCreateFields(type);
   const collectionFields = fields.filter((fieldSchema) => !fieldSchema.system && !EXTRA_SYSTEM_FIELDS.includes(fieldSchema.name)).map((fieldSchema) => createTypeCreateField(name, fieldSchema)).sort().join("\n");
-  return `export type ${typeName}Create = ${collectionFields ? `{
+  return `export type ${typeName}Create${genericArgs} = ${collectionFields ? `{
 ${collectionFields}
 } & ${systemFields}` : systemFields}`;
 }
 function createUpdateType(collectionSchemaEntry) {
   const { name, fields, type } = collectionSchemaEntry;
   const typeName = toPascalCase(name);
+  const genericArgs = getGenericArgStringWithDefault(fields, {
+    includeExpand: false
+  });
   if (name === "users") {
     console.log(name, type, fields);
   }
   const systemFields = getSystemUpdateFields(type);
   const collectionFields = fields.filter((fieldSchema) => !fieldSchema.system && !EXTRA_SYSTEM_FIELDS.includes(fieldSchema.name)).map((fieldSchema) => createTypeUpdateField(name, fieldSchema)).sort().join("\n");
-  return `export type ${typeName}Update = ${collectionFields ? `{
+  return `export type ${typeName}Update${genericArgs} = ${collectionFields ? `{
 ${collectionFields}
 } & ${systemFields}` : systemFields}`;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -58,6 +58,63 @@ async function fromURL(url, email = "", password = "") {
   return collections;
 }
 
+// src/constants.ts
+var EXPORT_COMMENT = `/**
+* This file was @generated using pocketbase-typegen
+*/`;
+var IMPORTS = `import type PocketBase from 'pocketbase'
+import type { RecordService } from 'pocketbase'`;
+var RECORD_TYPE_COMMENT = `// Record types for each collection`;
+var CREATE_TYPE_COMMENT = `// Create types for each collection`;
+var UPDATE_TYPE_COMMENT = `// Update types for each collection`;
+var RESPONSE_TYPE_COMMENT = `// Response types include system fields and match responses from the PocketBase API`;
+var ALL_RECORD_RESPONSE_COMMENT = `// Types containing all Records and Responses, useful for creating typing helper functions`;
+var TYPED_POCKETBASE_COMMENT = `// Type for usage with type asserted PocketBase instance
+// https://github.com/pocketbase/js-sdk#specify-typescript-definitions`;
+var EXPAND_GENERIC_NAME = "expand";
+var DATE_STRING_TYPE_NAME = `IsoDateString`;
+var RECORD_ID_STRING_NAME = `RecordIdString`;
+var HTML_STRING_NAME = `HTMLString`;
+var ALIAS_TYPE_DEFINITIONS = `// Alias types for improved usability
+export type ${DATE_STRING_TYPE_NAME} = string
+export type ${RECORD_ID_STRING_NAME} = string
+export type ${HTML_STRING_NAME} = string`;
+var NOT_COMMON_COLLECTIONS = ["_authOrigins", "_externalAuths", "_mfas", "_otps"];
+var EXTRA_SYSTEM_FIELDS = ["created", "updated"];
+var BASE_SYSTEM_FIELDS_DEFINITION = `// System fields
+export type BaseSystemFields<T = never> = {
+	id: ${RECORD_ID_STRING_NAME}
+	collectionId: string
+	collectionName: Collections
+	expand?: T
+}`;
+var BASE_SYSTEM_CREATE_FIELDS_DEFINITION = `export type BaseSystemCreateFields = {
+	id?: ${RECORD_ID_STRING_NAME}
+}`;
+var BASE_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type BaseSystemUpdateFields = never`;
+var AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields<T = never> = {
+	email: string
+	emailVisibility: boolean
+	username: string
+	verified: boolean
+} & BaseSystemFields<T>`;
+var AUTH_SYSTEM_CREATE_FIELDS_DEFINITION = `export type AuthSystemCreateFields = {
+	id?: ${RECORD_ID_STRING_NAME}
+	email: string
+	emailVisibility?: boolean
+	password: string
+	passwordConfirm: string
+	verified?: boolean
+}`;
+var AUTH_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type AuthSystemUpdateFields = {
+	email?: string
+	emailVisibility?: boolean
+	oldPassword?: string
+	password?: string
+	passwordConfirm?: string
+	verified?: boolean
+}`;
+
 // src/utils.ts
 import { promises as fs2 } from "fs";
 function toPascalCase(str) {
@@ -124,6 +181,18 @@ function createCollectionRecords(collectionNames) {
 ${nameRecordMap}
 }`;
 }
+function createCollectionCreates(collectionNames) {
+  const nameRecordMap = collectionNames.filter((name) => !NOT_COMMON_COLLECTIONS.includes(name)).map((name) => `	${name}: ${toPascalCase(name)}Create`).join("\n");
+  return `export type CollectionCreates = {
+${nameRecordMap}
+}`;
+}
+function createCollectionUpdates(collectionNames) {
+  const nameRecordMap = collectionNames.filter((name) => !NOT_COMMON_COLLECTIONS.includes(name)).map((name) => `	${name}: ${toPascalCase(name)}Update`).join("\n");
+  return `export type CollectionUpdates = {
+${nameRecordMap}
+}`;
+}
 function createCollectionResponses(collectionNames) {
   const nameRecordMap = collectionNames.map((name) => `	${name}: ${toPascalCase(name)}Response`).join("\n");
   return `export type CollectionResponses = {
@@ -140,63 +209,6 @@ function createTypedPocketbase(collectionNames) {
 ${nameRecordMap}
 }`;
 }
-
-// src/constants.ts
-var EXPORT_COMMENT = `/**
-* This file was @generated using pocketbase-typegen
-*/`;
-var IMPORTS = `import type PocketBase from 'pocketbase'
-import type { RecordService } from 'pocketbase'`;
-var RECORD_TYPE_COMMENT = `// Record types for each collection`;
-var CREATE_TYPE_COMMENT = `// Create types for each collection`;
-var UPDATE_TYPE_COMMENT = `// Update types for each collection`;
-var RESPONSE_TYPE_COMMENT = `// Response types include system fields and match responses from the PocketBase API`;
-var ALL_RECORD_RESPONSE_COMMENT = `// Types containing all Records and Responses, useful for creating typing helper functions`;
-var TYPED_POCKETBASE_COMMENT = `// Type for usage with type asserted PocketBase instance
-// https://github.com/pocketbase/js-sdk#specify-typescript-definitions`;
-var EXPAND_GENERIC_NAME = "expand";
-var DATE_STRING_TYPE_NAME = `IsoDateString`;
-var RECORD_ID_STRING_NAME = `RecordIdString`;
-var HTML_STRING_NAME = `HTMLString`;
-var ALIAS_TYPE_DEFINITIONS = `// Alias types for improved usability
-export type ${DATE_STRING_TYPE_NAME} = string
-export type ${RECORD_ID_STRING_NAME} = string
-export type ${HTML_STRING_NAME} = string`;
-var NOT_COMMON_COLLECTIONS = ["_authOrigins", "_externalAuths", "_mfas", "_otps"];
-var EXTRA_SYSTEM_FIELDS = ["created", "updated"];
-var BASE_SYSTEM_FIELDS_DEFINITION = `// System fields
-export type BaseSystemFields<T = never> = {
-	id: ${RECORD_ID_STRING_NAME}
-	collectionId: string
-	collectionName: Collections
-	expand?: T
-}`;
-var BASE_SYSTEM_CREATE_FIELDS_DEFINITION = `export type BaseSystemCreateFields = {
-	id?: ${RECORD_ID_STRING_NAME}
-}`;
-var BASE_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type BaseSystemUpdateFields = never`;
-var AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields<T = never> = {
-	email: string
-	emailVisibility: boolean
-	username: string
-	verified: boolean
-} & BaseSystemFields<T>`;
-var AUTH_SYSTEM_CREATE_FIELDS_DEFINITION = `export type AuthSystemCreateFields = {
-	id?: ${RECORD_ID_STRING_NAME}
-	email: string
-	emailVisibility?: boolean
-	password: string
-	passwordConfirm: string
-	verified?: boolean
-}`;
-var AUTH_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type AuthSystemUpdateFields = {
-	email?: string
-	emailVisibility?: boolean
-	oldPassword?: string
-	password?: string
-	passwordConfirm?: string
-	verified?: boolean
-}`;
 
 // src/generics.ts
 function fieldNameToGeneric(name) {
@@ -341,6 +353,8 @@ function generate(results, options2) {
     responseTypes.join("\n"),
     ALL_RECORD_RESPONSE_COMMENT,
     createCollectionRecords(sortedCollectionNames),
+    createCollectionCreates(sortedCollectionNames),
+    createCollectionUpdates(sortedCollectionNames),
     createCollectionResponses(sortedCollectionNames),
     options2.sdk && TYPED_POCKETBASE_COMMENT,
     options2.sdk && createTypedPocketbase(sortedCollectionNames)

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -1,3 +1,4 @@
+import { NOT_COMMON_COLLECTIONS } from "./constants"
 import { toPascalCase } from "./utils"
 
 export function createCollectionEnum(collectionNames: Array<string>): string {
@@ -17,6 +18,30 @@ export function createCollectionRecords(
     .map((name) => `\t${name}: ${toPascalCase(name)}Record`)
     .join("\n")
   return `export type CollectionRecords = {
+${nameRecordMap}
+}`
+}
+
+export function createCollectionCreates(
+  collectionNames: Array<string>
+): string {
+  const nameRecordMap = collectionNames
+    .filter((name) => !NOT_COMMON_COLLECTIONS.includes(name))
+    .map((name) => `\t${name}: ${toPascalCase(name)}Create`)
+    .join("\n")
+  return `export type CollectionCreates = {
+${nameRecordMap}
+}`
+}
+
+export function createCollectionUpdates(
+  collectionNames: Array<string>
+): string {
+  const nameRecordMap = collectionNames
+    .filter((name) => !NOT_COMMON_COLLECTIONS.includes(name))
+    .map((name) => `\t${name}: ${toPascalCase(name)}Update`)
+    .join("\n")
+  return `export type CollectionUpdates = {
 ${nameRecordMap}
 }`
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ export const EXPORT_COMMENT = `/**
 export const IMPORTS = `import type PocketBase from 'pocketbase'
 import type { RecordService } from 'pocketbase'`
 export const RECORD_TYPE_COMMENT = `// Record types for each collection`
+export const CREATE_TYPE_COMMENT = `// Create types for each collection`
+export const UPDATE_TYPE_COMMENT = `// Update types for each collection`
 export const RESPONSE_TYPE_COMMENT = `// Response types include system fields and match responses from the PocketBase API`
 export const ALL_RECORD_RESPONSE_COMMENT = `// Types containing all Records and Responses, useful for creating typing helper functions`
 export const TYPED_POCKETBASE_COMMENT = `// Type for usage with type asserted PocketBase instance\n// https://github.com/pocketbase/js-sdk#specify-typescript-definitions`
@@ -15,6 +17,8 @@ export const ALIAS_TYPE_DEFINITIONS = `// Alias types for improved usability
 export type ${DATE_STRING_TYPE_NAME} = string
 export type ${RECORD_ID_STRING_NAME} = string
 export type ${HTML_STRING_NAME} = string`
+export const NOT_COMMON_COLLECTIONS = ['_authOrigins', '_externalAuths', '_mfas', '_otps']
+export const EXTRA_SYSTEM_FIELDS = ['created', 'updated']
 
 export const BASE_SYSTEM_FIELDS_DEFINITION = `// System fields
 export type BaseSystemFields<T = never> = {
@@ -24,9 +28,33 @@ export type BaseSystemFields<T = never> = {
 \texpand?: T
 }`
 
+export const BASE_SYSTEM_CREATE_FIELDS_DEFINITION = `export type BaseSystemCreateFields = {
+\tid?: ${RECORD_ID_STRING_NAME}
+}`
+
+export const BASE_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type BaseSystemUpdateFields = never`
+
 export const AUTH_SYSTEM_FIELDS_DEFINITION = `export type AuthSystemFields<T = never> = {
 \temail: string
 \temailVisibility: boolean
 \tusername: string
 \tverified: boolean
 } & BaseSystemFields<T>`
+
+export const AUTH_SYSTEM_CREATE_FIELDS_DEFINITION = `export type AuthSystemCreateFields = {
+\tid?: ${RECORD_ID_STRING_NAME}
+\temail: string
+\temailVisibility?: boolean
+\tpassword: string
+\tpasswordConfirm: string
+\tverified?: boolean
+}`
+
+export const AUTH_SYSTEM_UPDATE_FIELDS_DEFINITION = `export type AuthSystemUpdateFields = {
+\temail?: string
+\temailVisibility?: boolean
+\toldPassword?: string
+\tpassword?: string
+\tpasswordConfirm?: string
+\tverified?: boolean
+}`

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -121,6 +121,9 @@ export function createCreateType(
 ): string {
   const { name, fields, type } = collectionSchemaEntry
   const typeName = toPascalCase(name)
+  const genericArgs = getGenericArgStringWithDefault(fields, {
+    includeExpand: false,
+  })
   const systemFields = getSystemCreateFields(type)
   const collectionFields = fields
     .filter((fieldSchema: FieldSchema) => !fieldSchema.system && !EXTRA_SYSTEM_FIELDS.includes(fieldSchema.name))
@@ -128,7 +131,7 @@ export function createCreateType(
     .sort()
     .join("\n")
 
-  return `export type ${typeName}Create = ${
+  return `export type ${typeName}Create${genericArgs} = ${
     collectionFields
       ? `{
 ${collectionFields}
@@ -142,9 +145,9 @@ export function createUpdateType(
 ): string {
   const { name, fields, type } = collectionSchemaEntry
   const typeName = toPascalCase(name)
-  if (name === 'users') {
-    console.log(name, type, fields);
-  }
+  const genericArgs = getGenericArgStringWithDefault(fields, {
+    includeExpand: false,
+  })
   const systemFields = getSystemUpdateFields(type)
   const collectionFields = fields
     .filter((fieldSchema: FieldSchema) => !fieldSchema.system && !EXTRA_SYSTEM_FIELDS.includes(fieldSchema.name))
@@ -152,7 +155,7 @@ export function createUpdateType(
     .sort()
     .join("\n")
 
-  return `export type ${typeName}Update = ${
+  return `export type ${typeName}Update${genericArgs} = ${
     collectionFields
       ? `{
 ${collectionFields}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,9 @@
 import {
+  createCollectionCreates,
   createCollectionEnum,
   createCollectionRecords,
   createCollectionResponses,
+  createCollectionUpdates,
   createTypedPocketbase,
 } from "./collections"
 import {
@@ -81,6 +83,8 @@ export function generate(
     responseTypes.join("\n"),
     ALL_RECORD_RESPONSE_COMMENT,
     createCollectionRecords(sortedCollectionNames),
+    createCollectionCreates(sortedCollectionNames),
+    createCollectionUpdates(sortedCollectionNames),
     createCollectionResponses(sortedCollectionNames),
     options.sdk && TYPED_POCKETBASE_COMMENT,
     options.sdk && createTypedPocketbase(sortedCollectionNames),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,26 @@ export function getSystemFields(type: CollectionRecord["type"]) {
   }
 }
 
+export function getSystemCreateFields(type: CollectionRecord["type"]) {
+  switch (type) {
+    case "auth":
+      return "AuthSystemCreateFields"
+    default:
+      // `view` and `base` collection types share the same system fields (for now)
+      return "BaseSystemCreateFields"
+  }
+}
+
+export function getSystemUpdateFields(type: CollectionRecord["type"]) {
+  switch (type) {
+    case "auth":
+      return "AuthSystemUpdateFields"
+    default:
+      // `view` and `base` collection types share the same system fields (for now)
+      return "BaseSystemUpdateFields"
+  }
+}
+
 export function getOptionEnumName(recordName: string, fieldName: string) {
   return `${toPascalCase(recordName)}${toPascalCase(fieldName)}Options`
 }

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -35,12 +35,36 @@ export type BaseSystemFields<T = never> = {
 	expand?: T
 }
 
+export type BaseSystemCreateFields = {
+	id?: RecordIdString
+}
+
+export type BaseSystemUpdateFields = never
+
 export type AuthSystemFields<T = never> = {
 	email: string
 	emailVisibility: boolean
 	username: string
 	verified: boolean
 } & BaseSystemFields<T>
+
+export type AuthSystemCreateFields = {
+	id?: RecordIdString
+	email: string
+	emailVisibility?: boolean
+	password: string
+	passwordConfirm: string
+	verified?: boolean
+}
+
+export type AuthSystemUpdateFields = {
+	email?: string
+	emailVisibility?: boolean
+	oldPassword?: string
+	password?: string
+	passwordConfirm?: string
+	verified?: boolean
+}
 
 // Record types for each collection
 
@@ -171,6 +195,102 @@ export type UsersRecord = {
 	verified?: boolean
 }
 
+// Create types for each collection
+
+export type SuperusersCreate = AuthSystemCreateFields
+
+export type BaseCreate = {
+	field?: string
+} & BaseSystemCreateFields
+
+export type CustomAuthCreate = {
+	custom_field?: string
+} & AuthSystemCreateFields
+
+export type EverythingCreate<Tanother_json_field = unknown, Tjson_field = unknown> = {
+	another_json_field?: null | Tanother_json_field
+	bool_field?: boolean
+	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: File
+	json_field?: null | Tjson_field
+	number_field?: number
+	post_relation_field?: RecordIdString
+	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: File[]
+	url_field?: string
+	user_relation_field?: RecordIdString
+} & BaseSystemCreateFields
+
+export type MyViewCreate<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
+	post_relation_field?: RecordIdString
+	text_field?: string
+} & BaseSystemCreateFields
+
+export type PostsCreate = {
+	field1?: number
+	nonempty_bool: boolean
+	nonempty_field: string
+} & BaseSystemCreateFields
+
+export type UsersCreate = {
+	avatar?: File
+	name?: string
+} & AuthSystemCreateFields
+
+// Update types for each collection
+
+export type SuperusersUpdate = AuthSystemUpdateFields
+
+export type BaseUpdate = {
+	field?: string
+} & BaseSystemUpdateFields
+
+export type CustomAuthUpdate = {
+	custom_field?: string
+} & AuthSystemUpdateFields
+
+export type EverythingUpdate<Tanother_json_field = unknown, Tjson_field = unknown> = {
+	another_json_field?: null | Tanother_json_field
+	bool_field?: boolean
+	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: File
+	json_field?: null | Tjson_field
+	number_field?: number
+	post_relation_field?: RecordIdString
+	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: File[]
+	url_field?: string
+	user_relation_field?: RecordIdString
+} & BaseSystemUpdateFields
+
+export type MyViewUpdate<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
+	post_relation_field?: RecordIdString
+	text_field?: string
+} & BaseSystemUpdateFields
+
+export type PostsUpdate = {
+	field1?: number
+	nonempty_bool?: boolean
+	nonempty_field?: string
+} & BaseSystemUpdateFields
+
+export type UsersUpdate = {
+	avatar?: File
+	name?: string
+} & AuthSystemUpdateFields
+
 // Response types include system fields and match responses from the PocketBase API
 export type AuthoriginsResponse<Texpand = unknown> = Required<AuthoriginsRecord> & BaseSystemFields<Texpand>
 export type ExternalauthsResponse<Texpand = unknown> = Required<ExternalauthsRecord> & BaseSystemFields<Texpand>
@@ -198,6 +318,26 @@ export type CollectionRecords = {
 	my_view: MyViewRecord
 	posts: PostsRecord
 	users: UsersRecord
+}
+
+export type CollectionCreates = {
+	_superusers: SuperusersCreate
+	base: BaseCreate
+	custom_auth: CustomAuthCreate
+	everything: EverythingCreate
+	my_view: MyViewCreate
+	posts: PostsCreate
+	users: UsersCreate
+}
+
+export type CollectionUpdates = {
+	_superusers: SuperusersUpdate
+	base: BaseUpdate
+	custom_auth: CustomAuthUpdate
+	everything: EverythingUpdate
+	my_view: MyViewUpdate
+	posts: PostsUpdate
+	users: UsersUpdate
 }
 
 export type CollectionResponses = {

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -45,6 +45,12 @@ export type BaseSystemFields<T = never> = {
 	expand?: T
 }
 
+export type BaseSystemCreateFields = {
+	id?: RecordIdString
+}
+
+export type BaseSystemUpdateFields = never
+
 export type AuthSystemFields<T = never> = {
 	email: string
 	emailVisibility: boolean
@@ -52,11 +58,41 @@ export type AuthSystemFields<T = never> = {
 	verified: boolean
 } & BaseSystemFields<T>
 
+export type AuthSystemCreateFields = {
+	id?: RecordIdString
+	email: string
+	emailVisibility?: boolean
+	password: string
+	passwordConfirm: string
+	verified?: boolean
+}
+
+export type AuthSystemUpdateFields = {
+	email?: string
+	emailVisibility?: boolean
+	oldPassword?: string
+	password?: string
+	passwordConfirm?: string
+	verified?: boolean
+}
+
 // Record types for each collection
 
 export type BooksRecord = {
 	title?: string
 }
+
+// Create types for each collection
+
+export type BooksCreate = {
+	title?: string
+} & BaseSystemCreateFields
+
+// Update types for each collection
+
+export type BooksUpdate = {
+	title?: string
+} & BaseSystemUpdateFields
 
 // Response types include system fields and match responses from the PocketBase API
 export type BooksResponse<Texpand = unknown> = Required<BooksRecord> & BaseSystemFields<Texpand>
@@ -65,6 +101,14 @@ export type BooksResponse<Texpand = unknown> = Required<BooksRecord> & BaseSyste
 
 export type CollectionRecords = {
 	books: BooksRecord
+}
+
+export type CollectionCreates = {
+	books: BooksCreate
+}
+
+export type CollectionUpdates = {
+	books: BooksUpdate
 }
 
 export type CollectionResponses = {

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -32,12 +32,36 @@ export type BaseSystemFields<T = never> = {
 	expand?: T
 }
 
+export type BaseSystemCreateFields = {
+	id?: RecordIdString
+}
+
+export type BaseSystemUpdateFields = never
+
 export type AuthSystemFields<T = never> = {
 	email: string
 	emailVisibility: boolean
 	username: string
 	verified: boolean
 } & BaseSystemFields<T>
+
+export type AuthSystemCreateFields = {
+	id?: RecordIdString
+	email: string
+	emailVisibility?: boolean
+	password: string
+	passwordConfirm: string
+	verified?: boolean
+}
+
+export type AuthSystemUpdateFields = {
+	email?: string
+	emailVisibility?: boolean
+	oldPassword?: string
+	password?: string
+	passwordConfirm?: string
+	verified?: boolean
+}
 
 // Record types for each collection
 
@@ -168,6 +192,102 @@ export type UsersRecord = {
 	verified?: boolean
 }
 
+// Create types for each collection
+
+export type SuperusersCreate = AuthSystemCreateFields
+
+export type BaseCreate = {
+	field?: string
+} & BaseSystemCreateFields
+
+export type CustomAuthCreate = {
+	custom_field?: string
+} & AuthSystemCreateFields
+
+export type EverythingCreate<Tanother_json_field = unknown, Tjson_field = unknown> = {
+	another_json_field?: null | Tanother_json_field
+	bool_field?: boolean
+	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: File
+	json_field?: null | Tjson_field
+	number_field?: number
+	post_relation_field?: RecordIdString
+	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: File[]
+	url_field?: string
+	user_relation_field?: RecordIdString
+} & BaseSystemCreateFields
+
+export type MyViewCreate<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
+	post_relation_field?: RecordIdString
+	text_field?: string
+} & BaseSystemCreateFields
+
+export type PostsCreate = {
+	field1?: number
+	nonempty_bool: boolean
+	nonempty_field: string
+} & BaseSystemCreateFields
+
+export type UsersCreate = {
+	avatar?: File
+	name?: string
+} & AuthSystemCreateFields
+
+// Update types for each collection
+
+export type SuperusersUpdate = AuthSystemUpdateFields
+
+export type BaseUpdate = {
+	field?: string
+} & BaseSystemUpdateFields
+
+export type CustomAuthUpdate = {
+	custom_field?: string
+} & AuthSystemUpdateFields
+
+export type EverythingUpdate<Tanother_json_field = unknown, Tjson_field = unknown> = {
+	another_json_field?: null | Tanother_json_field
+	bool_field?: boolean
+	custom_relation_field?: RecordIdString[]
+	date_field?: IsoDateString
+	email_field?: string
+	file_field?: File
+	json_field?: null | Tjson_field
+	number_field?: number
+	post_relation_field?: RecordIdString
+	rich_editor_field?: HTMLString
+	select_field?: EverythingSelectFieldOptions
+	select_field_no_values?: string
+	text_field?: string
+	three_files_field?: File[]
+	url_field?: string
+	user_relation_field?: RecordIdString
+} & BaseSystemUpdateFields
+
+export type MyViewUpdate<Tjson_field = unknown> = {
+	json_field?: null | Tjson_field
+	post_relation_field?: RecordIdString
+	text_field?: string
+} & BaseSystemUpdateFields
+
+export type PostsUpdate = {
+	field1?: number
+	nonempty_bool?: boolean
+	nonempty_field?: string
+} & BaseSystemUpdateFields
+
+export type UsersUpdate = {
+	avatar?: File
+	name?: string
+} & AuthSystemUpdateFields
+
 // Response types include system fields and match responses from the PocketBase API
 export type AuthoriginsResponse<Texpand = unknown> = Required<AuthoriginsRecord> & BaseSystemFields<Texpand>
 export type ExternalauthsResponse<Texpand = unknown> = Required<ExternalauthsRecord> & BaseSystemFields<Texpand>
@@ -195,6 +315,26 @@ export type CollectionRecords = {
 	my_view: MyViewRecord
 	posts: PostsRecord
 	users: UsersRecord
+}
+
+export type CollectionCreates = {
+	_superusers: SuperusersCreate
+	base: BaseCreate
+	custom_auth: CustomAuthCreate
+	everything: EverythingCreate
+	my_view: MyViewCreate
+	posts: PostsCreate
+	users: UsersCreate
+}
+
+export type CollectionUpdates = {
+	_superusers: SuperusersUpdate
+	base: BaseUpdate
+	custom_auth: CustomAuthUpdate
+	everything: EverythingUpdate
+	my_view: MyViewUpdate
+	posts: PostsUpdate
+	users: UsersUpdate
 }
 
 export type CollectionResponses = {


### PR DESCRIPTION
#110 This PR adds the generation of types for Create and Update requests.
Also, using the new generated types for create/update I think #65 can be solved due to the proper typing of "file" fields.

(Collections `_authOrigins,_externalAuths,_mfas and _otps` were excluded from this PR as they are internal and I think it is very rare to create/update them via API)