### PR TITLE
Implement token auth CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ URL example with email and password:
 
 URL example with auth token:
 
+You can generate such token via the above impersonate API or from the Dashboard > Collections > _superusers > {select superuser} > "Impersonate" dropdown option.
+
 `npx pocketbase-typegen --url https://myproject.pockethost.io --token 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'`
 
 ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file):

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Options:
   -V, --version          output the version number
   -d, --db <char>        path to the pocketbase SQLite database
   -j, --json <char>      path to JSON schema exported from pocketbase admin UI
-  -u, --url <char>       URL to your hosted pocketbase instance. When using this options you must also provide email and password options.
-  --email <char>     email for an admin pocketbase user. Use this with the --url option
-  -p, --password <char>  password for an admin pocketbase user. Use this with the --url option
+  -u, --url <char>       URL to your hosted pocketbase instance. When using this options you must also provide email and password options or auth token option
+  --email <char>         email for a pocketbase superuser. Use this with the --url option
+  -p, --password <char>  password for a pocketbase superuser. Use this with the --url option
+  -t, --token <char>     auth token for a pocketbase superuser. Alternative to email and password authentication. Use this with the --url option
   -o, --out <char>       path to save the typescript output file (default: "pocketbase-types.ts")
   --no-sdk               remove the pocketbase package dependency. A typed version of the SDK will not be generated.
   --env [path]       flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file
@@ -41,9 +42,13 @@ JSON example (export JSON schema from the pocketbase admin dashboard):
 
 `npx pocketbase-typegen --json ./pb_schema.json`
 
-URL example:
+URL example with email and password:
 
 `npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject.com --password 'secr3tp@ssword!'`
+
+URL example with auth token:
+
+`npx pocketbase-typegen --url https://myproject.pockethost.io --token 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'`
 
 ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file):
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,12 @@
 import dotenv from "dotenv"
 
 import type { CollectionRecord, Options } from "./types"
-import { fromDatabase, fromJSON, fromURL } from "./schema"
+import {
+  fromDatabase,
+  fromJSON,
+  fromURLWithPassword,
+  fromURLWithToken,
+} from "./schema"
 
 import { generate } from "./lib"
 import { saveFile } from "./utils"
@@ -12,8 +17,14 @@ export async function main(options: Options) {
     schema = await fromDatabase(options.db)
   } else if (options.json) {
     schema = await fromJSON(options.json)
+  } else if (options.url && options.token) {
+    schema = await fromURLWithToken(options.url, options.token)
   } else if (options.url) {
-    schema = await fromURL(options.url, options.email, options.password)
+    schema = await fromURLWithPassword(
+      options.url,
+      options.email,
+      options.password
+    )
   } else if (options.env) {
     const path: string = typeof options.env === "string" ? options.env : ".env"
     dotenv.config({ path: path })
@@ -26,7 +37,7 @@ export async function main(options: Options) {
         "Missing environment variables. Check options: pocketbase-typegen --help"
       )
     }
-    schema = await fromURL(
+    schema = await fromURLWithPassword(
       process.env.PB_TYPEGEN_URL,
       process.env.PB_TYPEGEN_EMAIL,
       process.env.PB_TYPEGEN_PASSWORD

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,19 @@ program
   )
   .option(
     "-u, --url <char>",
-    "URL to your hosted pocketbase instance. When using this options you must also provide email and password options."
+    "URL to your hosted pocketbase instance. When using this options you must also provide email and password options or auth token option."
   )
   .option(
     "--email <char>",
-    "email for an admin pocketbase user. Use this with the --url option"
+    "email for a pocketbase superuser. Use this with the --url option"
   )
   .option(
     "-p, --password <char>",
-    "password for an admin pocketbase user. Use this with the --url option"
+    "password for a pocketbase superuser. Use this with the --url option"
+  )
+  .option(
+    "-t, --token <char>",
+    "auth token for a pocketbase superuser. Use this with the --url option"
   )
   .option(
     "-o, --out <char>",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -25,30 +25,12 @@ export async function fromJSON(path: string): Promise<Array<CollectionRecord>> {
   return JSON.parse(schemaStr)
 }
 
-export async function fromURL(
+export async function fromURLWithToken(
   url: string,
-  email = "",
-  password = ""
+  token: string = ""
 ): Promise<Array<CollectionRecord>> {
-  const formData = new FormData()
-  formData.append("identity", email)
-  formData.append("password", password)
   let collections: Array<CollectionRecord> = []
   try {
-    // Login
-    const { token } = await fetch(
-      `${url}/api/collections/_superusers/auth-with-password`,
-      {
-        // @ts-ignore
-        body: formData,
-        method: "post",
-      }
-    ).then((res) => {
-      if (!res.ok) throw res
-      return res.json()
-    })
-
-    // Get the collections
     const result = await fetch(`${url}/api/collections?perPage=200`, {
       headers: {
         Authorization: token,
@@ -64,4 +46,37 @@ export async function fromURL(
   }
 
   return collections
+}
+
+export async function fromURLWithPassword(
+  url: string,
+  email = "",
+  password = ""
+): Promise<Array<CollectionRecord>> {
+  const formData = new FormData()
+  formData.append("identity", email)
+  formData.append("password", password)
+
+  let token: string
+  try {
+    // Login
+    const response = await fetch(
+      `${url}/api/collections/_superusers/auth-with-password`,
+      {
+        // @ts-ignore
+        body: formData,
+        method: "post",
+      }
+    ).then((res) => {
+      if (!res.ok) throw res
+      return res.json()
+    })
+
+    token = response.token
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+
+  return await fromURLWithToken(url, token)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Options = {
   json?: string
   email?: string
   password?: string
+  token?: string
   sdk?: boolean
   env?: boolean | string
 }


### PR DESCRIPTION
In November 2024, PocketBase released version 23 with new impersonate feature:

> Impersonate Web API endpoint (it could be also used for generating fixed/non-refreshable superuser tokens, aka. "API keys"). 

The token can be generated in the admin dashboard and can be used on server to authenticate the PocketBase instance as a superuser.

Right now, typegen doesn't support authenticating with this token yet. If I want to use the token for PB auth (since I find it cleaner compared to email & password), I also need to set (redundant) email and password environment variables. The pocketbase-typegen wouldn't otherwise work in pipeline. 

The suggested fix is very easy and I will gladly change anything in order to get this merged:)

I tested this manually and I am not sure if it is possible to write a test, since the token must be generated first. 

Should I also bump the version?