### PR TITLE
Fixed Pocketbase compatibility

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17,7 +17,7 @@ async function fromDatabase(dbPath) {
   const result = await db.all("SELECT * FROM _collections");
   return result.map((collection) => ({
     ...collection,
-    fields: JSON.parse(collection.fields)
+    fields: JSON.parse(collection.fields ?? collection.schema ?? "{}")
   }));
 }
 async function fromJSON(path) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,7 +16,7 @@ export async function fromDatabase(
   const result = await db.all("SELECT * FROM _collections")
   return result.map((collection) => ({
     ...collection,
-    fields: JSON.parse(collection.fields),
+    fields: JSON.parse(collection.fields ?? collection.schema  ?? "{}"),
   }))
 }
 


### PR DESCRIPTION
This PR will introduce a fix when using the latest pocketbase (0.27.1) version while being backwards compatible.

- It will check for both files collection.schema and collection.fields