### PR TITLE
support .env overrides and token based auth in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ This will produce types for all your PocketBase collections to use in your front
 ```
 Options:
   -V, --version              output the version number
-  -d, --db <path>            Path to the pocketbase SQLite database.
-  -j, --json <path>          Path to JSON schema exported from pocketbase admin UI.
   -u, --url <url>            URL to your hosted pocketbase instance. When using this options you must also provide email and
                              password options or auth token option.
   --email <email>            Email for a pocketbase superuser. Use this with the --url option.
   -p, --password <password>  Password for a pocketbase superuser. Use this with the --url option.
   -t, --token <token>        Auth token for a pocketbase superuser. Use this with the --url option.
+  -d, --db <path>            Path to the pocketbase SQLite database.
+  -j, --json <path>          Path to JSON schema exported from pocketbase admin UI.
+  --env [dir]                Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD
+                             to your .env file. Optionally provide a path to a directory containing a .env file (default: true)
   -o, --out <path>           Path to save the typescript output file. (default: "pocketbase-types.ts")
   --no-sdk                   Removes the pocketbase package dependency. A typed version of the SDK will not be generated.
-  --env <dir>                Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD
-                             to your .env file. Optionally provide a path to a directory containing a .env file
   -h, --help                 display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate typescript definitions from your [pocketbase.io](https://pocketbase.io/
 
 ## Quickstart
 
-`npx pocketbase-typegen --db ./pb_data/data.db --out pocketbase-types.ts`
+`npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject.com --password 'secr3tp@ssword!'`
 
 This will produce types for all your PocketBase collections to use in your frontend typescript codebase.
 
@@ -21,17 +21,19 @@ This will produce types for all your PocketBase collections to use in your front
 
 ```
 Options:
-  -V, --version          output the version number
-  -d, --db <char>        path to the pocketbase SQLite database
-  -j, --json <char>      path to JSON schema exported from pocketbase admin UI
-  -u, --url <char>       URL to your hosted pocketbase instance. When using this options you must also provide email and password options or auth token option
-  --email <char>         email for a pocketbase superuser. Use this with the --url option
-  -p, --password <char>  password for a pocketbase superuser. Use this with the --url option
-  -t, --token <char>     auth token for a pocketbase superuser. Alternative to email and password authentication. Use this with the --url option
-  -o, --out <char>       path to save the typescript output file (default: "pocketbase-types.ts")
-  --no-sdk               remove the pocketbase package dependency. A typed version of the SDK will not be generated.
-  --env [path]       flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file
-  -h, --help             display help for command
+  -V, --version              output the version number
+  -d, --db <path>            Path to the pocketbase SQLite database.
+  -j, --json <path>          Path to JSON schema exported from pocketbase admin UI.
+  -u, --url <url>            URL to your hosted pocketbase instance. When using this options you must also provide email and
+                             password options or auth token option.
+  --email <email>            Email for a pocketbase superuser. Use this with the --url option.
+  -p, --password <password>  Password for a pocketbase superuser. Use this with the --url option.
+  -t, --token <token>        Auth token for a pocketbase superuser. Use this with the --url option.
+  -o, --out <path>           Path to save the typescript output file. (default: "pocketbase-types.ts")
+  --no-sdk                   Removes the pocketbase package dependency. A typed version of the SDK will not be generated.
+  --env <dir>                Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD
+                             to your .env file. Optionally provide a path to a directory containing a .env file
+  -h, --help                 display help for command
 ```
 
 ### URL example with email and password:
@@ -46,18 +48,17 @@ You can generate such token via the above impersonate API or from the Dashboard 
 
 ### ENV example:
 
-Also supports environment specific files such as .env.local
+Also supports environment specific files such as .env.local (uses [dotenv-flow](https://www.npmjs.com/package/dotenv-flow))
 
-`npx pocketbase-typegen --env`
-or
-`npx pocketbase-typegen --env path/to/.env`
+`npx pocketbase-typegen --env` or `npx pocketbase-typegen --env path/to/dir`
 
-.env:
+.env variables include:
 
 ```
 PB_TYPEGEN_URL=https://myproject.pockethost.io
 PB_TYPEGEN_EMAIL=admin@myproject.com
 PB_TYPEGEN_PASSWORD=secr3tp@ssword!
+PB_TYPEGEN_TOKEN=eyJhbGciOiJI...ozhyQVfYm24
 ```
 
 ### Database example:

--- a/README.md
+++ b/README.md
@@ -34,27 +34,23 @@ Options:
   -h, --help             display help for command
 ```
 
-DB example:
-
-`npx pocketbase-typegen --db ./pb_data/data.db`
-
-JSON example (export JSON schema from the pocketbase admin dashboard):
-
-`npx pocketbase-typegen --json ./pb_schema.json`
-
-URL example with email and password:
+### URL example with email and password:
 
 `npx pocketbase-typegen --url https://myproject.pockethost.io --email admin@myproject.com --password 'secr3tp@ssword!'`
 
-URL example with auth token:
+### URL example with auth token:
 
-You can generate such token via the above impersonate API or from the Dashboard > Collections > _superusers > {select superuser} > "Impersonate" dropdown option.
+You can generate such token via the above impersonate API or from the Dashboard > Collections > \_superusers > {select superuser} > "Impersonate" dropdown option.
 
 `npx pocketbase-typegen --url https://myproject.pockethost.io --token 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'`
 
-ENV example (add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL and PB_TYPEGEN_PASSWORD to your .env file):
+### ENV example:
+
+Also supports environment specific files such as .env.local
 
 `npx pocketbase-typegen --env`
+or
+`npx pocketbase-typegen --env path/to/.env`
 
 .env:
 
@@ -64,11 +60,21 @@ PB_TYPEGEN_EMAIL=admin@myproject.com
 PB_TYPEGEN_PASSWORD=secr3tp@ssword!
 ```
 
+### Database example:
+
+`npx pocketbase-typegen --db ./pb_data/data.db`
+
+### JSON example (export JSON schema from the pocketbase admin dashboard):
+
+`npx pocketbase-typegen --json ./pb_schema.json`
+
+### Shortcut
+
 Add it to your projects `package.json`:
 
 ```
 "scripts": {
-  "typegen": "pocketbase-typegen --db ./pb_data/data.db",
+  "typegen": "pocketbase-typegen --env",
 },
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "pocketbase-typegen",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocketbase-typegen",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "commander": "^9.4.1",
         "cross-fetch": "^3.1.5",
-        "dotenv": "^16.3.1",
+        "dotenv-flow": "^4.1.0",
         "form-data": "^4.0.0",
         "sqlite": "^4.1.2",
         "sqlite3": "^5.1.4"
@@ -2497,6 +2497,18 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/dotenv-flow": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-4.1.0.tgz",
+      "integrity": "sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8225,6 +8237,14 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+    },
+    "dotenv-flow": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-4.1.0.tgz",
+      "integrity": "sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==",
+      "requires": {
+        "dotenv": "^16.0.0"
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.281",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "commander": "^9.4.1",
     "cross-fetch": "^3.1.5",
-    "dotenv": "^16.3.1",
+    "dotenv-flow": "^4.1.0",
     "form-data": "^4.0.0",
     "sqlite": "^4.1.2",
     "sqlite3": "^5.1.4"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,20 +29,28 @@ export async function main(options: Options) {
     dotenv.config(
       typeof options.env === "string" ? { path: options.env } : undefined
     )
-    if (
-      !process.env.PB_TYPEGEN_URL ||
-      !process.env.PB_TYPEGEN_EMAIL ||
-      !process.env.PB_TYPEGEN_PASSWORD
+    if (!process.env.PB_TYPEGEN_URL) {
+      return console.error("Missing PB_TYPEGEN_URL environment variable")
+    }
+    if (process.env.PB_TYPEGEN_TOKEN) {
+      schema = await fromURLWithToken(
+        process.env.PB_TYPEGEN_URL,
+        process.env.PB_TYPEGEN_TOKEN
+      )
+    } else if (
+      process.env.PB_TYPEGEN_EMAIL &&
+      process.env.PB_TYPEGEN_PASSWORD
     ) {
+      schema = await fromURLWithPassword(
+        process.env.PB_TYPEGEN_URL,
+        process.env.PB_TYPEGEN_EMAIL,
+        process.env.PB_TYPEGEN_PASSWORD
+      )
+    } else {
       return console.error(
-        "Missing environment variables. Check options: pocketbase-typegen --help"
+        "Missing PB_TYPEGEN_URL or PB_TYPEGEN_TOKEN environment variables"
       )
     }
-    schema = await fromURLWithPassword(
-      process.env.PB_TYPEGEN_URL,
-      process.env.PB_TYPEGEN_EMAIL,
-      process.env.PB_TYPEGEN_PASSWORD
-    )
   } else {
     return console.error(
       "Missing schema path. Check options: pocketbase-typegen --help"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import dotenv from "dotenv"
+import dotenv from "dotenv-flow"
 
 import type { CollectionRecord, Options } from "./types"
 import {
@@ -26,8 +26,9 @@ export async function main(options: Options) {
       options.password
     )
   } else if (options.env) {
-    const path: string = typeof options.env === "string" ? options.env : ".env"
-    dotenv.config({ path: path })
+    dotenv.config(
+      typeof options.env === "string" ? { path: options.env } : undefined
+    )
     if (
       !process.env.PB_TYPEGEN_URL ||
       !process.env.PB_TYPEGEN_EMAIL ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,41 +9,41 @@ program
   .name("Pocketbase Typegen")
   .version(version)
   .description(
-    "CLI to create typescript typings for your pocketbase.io records"
+    "CLI to create typescript typings for your pocketbase.io records."
   )
-  .option("-d, --db <char>", "path to the pocketbase SQLite database")
+  .option("-d, --db <path>", "Path to the pocketbase SQLite database.")
   .option(
-    "-j, --json <char>",
-    "path to JSON schema exported from pocketbase admin UI"
+    "-j, --json <path>",
+    "Path to JSON schema exported from pocketbase admin UI."
   )
   .option(
-    "-u, --url <char>",
+    "-u, --url <url>",
     "URL to your hosted pocketbase instance. When using this options you must also provide email and password options or auth token option."
   )
   .option(
-    "--email <char>",
-    "email for a pocketbase superuser. Use this with the --url option"
+    "--email <email>",
+    "Email for a pocketbase superuser. Use this with the --url option."
   )
   .option(
-    "-p, --password <char>",
-    "password for a pocketbase superuser. Use this with the --url option"
+    "-p, --password <password>",
+    "Password for a pocketbase superuser. Use this with the --url option."
   )
   .option(
-    "-t, --token <char>",
-    "auth token for a pocketbase superuser. Use this with the --url option"
+    "-t, --token <token>",
+    "Auth token for a pocketbase superuser. Use this with the --url option."
   )
   .option(
-    "-o, --out <char>",
-    "path to save the typescript output file",
+    "-o, --out <path>",
+    "Path to save the typescript output file.",
     "pocketbase-types.ts"
   )
   .option(
     "--no-sdk",
-    "remove the pocketbase package dependency. A typed version of the SDK will not be generated."
+    "Removes the pocketbase package dependency. A typed version of the SDK will not be generated."
   )
   .option(
-    "--env [path]",
-    "flag to use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to your .env file"
+    "--env <dir>",
+    "Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to a directory containing a .env file"
   )
 
 program.parse(process.argv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,6 @@ program
   .description(
     "CLI to create typescript typings for your pocketbase.io records."
   )
-  .option("-d, --db <path>", "Path to the pocketbase SQLite database.")
-  .option(
-    "-j, --json <path>",
-    "Path to JSON schema exported from pocketbase admin UI."
-  )
   .option(
     "-u, --url <url>",
     "URL to your hosted pocketbase instance. When using this options you must also provide email and password options or auth token option."
@@ -32,6 +27,16 @@ program
     "-t, --token <token>",
     "Auth token for a pocketbase superuser. Use this with the --url option."
   )
+  .option("-d, --db <path>", "Path to the pocketbase SQLite database.")
+  .option(
+    "-j, --json <path>",
+    "Path to JSON schema exported from pocketbase admin UI."
+  )
+  .option(
+    "--env [dir]",
+    "Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to a directory containing a .env file",
+    true
+  )
   .option(
     "-o, --out <path>",
     "Path to save the typescript output file.",
@@ -40,10 +45,6 @@ program
   .option(
     "--no-sdk",
     "Removes the pocketbase package dependency. A typed version of the SDK will not be generated."
-  )
-  .option(
-    "--env <dir>",
-    "Use environment variables for configuration. Add PB_TYPEGEN_URL, PB_TYPEGEN_EMAIL, PB_TYPEGEN_PASSWORD to your .env file. Optionally provide a path to a directory containing a .env file"
   )
 
 program.parse(process.argv)


### PR DESCRIPTION
- switch to dotenv-flow to support environment overrides (eg .env.local)
- add support for token based auth in .env

fixes https://github.com/patmood/pocketbase-typegen/issues/124