### PR TITLE
feature: Type relationships as `TExpand`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const EXPAND_TYPE_DEFINITION = `type ExpandType<T> = unknown extends T
 \t? T extends unknown
 \t\t? { expand?: unknown }
 \t\t: { expand: T }
-\t: { expand: T }`
+\t: { expand?: T }`
 
 export const GEOPOINT_TYPE_DEFINITION = `export type ${GEOPOINT_TYPE_NAME} = {
 \tlon: number

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -66,12 +66,14 @@ export function getGenericArgForExpand(
     return `\t${field.name}?: ${value}`
   })
 
-  const childrenFields = [...node.children.entries()].map(([field, collection]) => {
-    const name = `${collection.name}_via_${field.name}`
-    const value = `${toPascalCase(collection.name)}Record[]`
+  const childrenFields = [...node.children.entries()].map(
+    ([field, collection]) => {
+      const name = `${collection.name}_via_${field.name}`
+      const value = `${toPascalCase(collection.name)}Record[]`
 
-    return `\t${name}?: ${value}`
-  })
+      return `\t${name}?: ${value}`
+    }
+  )
 
   return `{
 ${[...ownerFields, ...childrenFields].join(",\n")}

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -60,11 +60,13 @@ export function getGenericArgForExpand(
     return "unknown"
   }
 
-  const ownerFields = [...lookupNode.parents.entries()].map(([field, parentNode]) => {
-    const value = `${toPascalCase(parentNode.name)}Record`
+  const ownerFields = [...lookupNode.parents.entries()].map(
+    ([field, parentNode]) => {
+      const value = `${toPascalCase(parentNode.name)}Record`
 
-    return `\t${field.name}?: ${value}`
-  })
+      return `\t${field.name}?: ${value}`
+    }
+  )
 
   const childrenFields = [...lookupNode.children.entries()].map(
     ([field, childNode]) => {

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -1,5 +1,6 @@
 import { EXPAND_GENERIC_NAME } from "./constants"
-import { FieldSchema } from "./types"
+import { CollectionRecord, FieldSchema, RelationGraph } from "./types"
+import { toPascalCase } from "./utils"
 
 export function fieldNameToGeneric(name: string) {
   return `T${name}`
@@ -21,14 +22,58 @@ export function getGenericArgStringForRecord(schema: FieldSchema[]): string {
 
 export function getGenericArgStringWithDefault(
   schema: FieldSchema[],
-  opts: { includeExpand: boolean }
+  opts:
+    | { includeExpand: false; relationGraph?: never; collectionId?: never }
+    | {
+        includeExpand: true
+        relationGraph: RelationGraph
+        collectionId: CollectionRecord["id"]
+      }
 ): string {
-  const argList = getGenericArgList(schema)
+  const argList = getGenericArgList(schema).map((name) => `${name} = unknown`)
 
   if (opts.includeExpand) {
-    argList.push(fieldNameToGeneric(EXPAND_GENERIC_NAME))
+    const expandArg = getGenericArgForExpand(
+      opts.collectionId,
+      opts.relationGraph
+    )
+
+    argList.push(`${fieldNameToGeneric(EXPAND_GENERIC_NAME)} = ${expandArg}`)
   }
 
   if (argList.length === 0) return ""
-  return `<${argList.map((name) => `${name} = unknown`).join(", ")}>`
+
+  return `<${argList.join(", ")}>`
+}
+
+export function getGenericArgForExpand(
+  collectionId: CollectionRecord["id"],
+  relationGraph: RelationGraph
+): string {
+  const node = relationGraph.find((some) => some.id === collectionId)
+
+  if (!node) {
+    return "unknown"
+  }
+
+  if (node.children.size === 0 && node.owners.size === 0) {
+    return "unknown"
+  }
+
+  const ownerFields = [...node.owners.entries()].map(([field, collection]) => {
+    const value = `${toPascalCase(collection.name)}Record`
+
+    return `\t${field.name}?: ${value}`
+  })
+
+  const childrenFields = [...node.children.entries()].map(([field, collection]) => {
+    const name = `${collection.name}_via_${field.name}`
+    const value = `${toPascalCase(collection.name)}Record[]`
+
+    return `\t${name}?: ${value}`
+  })
+
+  return `{
+${[...ownerFields, ...childrenFields].join(",\n")}
+}`
 }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -62,7 +62,7 @@ export function getGenericArgForExpand(
 
   const parentFields = [...lookupNode.parents.entries()].map(
     ([field, parentNode]) => {
-      const value = `${toPascalCase(parentNode.name)}Record`
+      const value = `${toPascalCase(parentNode.name)}Response`
 
       return `\t${field.name}?: ${value}`
     }
@@ -71,7 +71,7 @@ export function getGenericArgForExpand(
   const childrenFields = [...lookupNode.children.entries()].map(
     ([field, childNode]) => {
       const name = `${childNode.name}_via_${field.name}`
-      const value = `${toPascalCase(childNode.name)}Record[]`
+      const value = `${toPascalCase(childNode.name)}Response[]`
 
       return `\t${name}?: ${value}`
     }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -50,26 +50,26 @@ export function getGenericArgForExpand(
   collectionId: CollectionRecord["id"],
   relationGraph: RelationGraph
 ): string {
-  const node = relationGraph.find((some) => some.id === collectionId)
+  const lookupNode = relationGraph.find((some) => some.id === collectionId)
 
-  if (!node) {
+  if (!lookupNode) {
     return "unknown"
   }
 
-  if (node.children.size === 0 && node.owners.size === 0) {
+  if (lookupNode.children.size === 0 && lookupNode.parents.size === 0) {
     return "unknown"
   }
 
-  const ownerFields = [...node.owners.entries()].map(([field, collection]) => {
-    const value = `${toPascalCase(collection.name)}Record`
+  const ownerFields = [...lookupNode.parents.entries()].map(([field, parentNode]) => {
+    const value = `${toPascalCase(parentNode.name)}Record`
 
     return `\t${field.name}?: ${value}`
   })
 
-  const childrenFields = [...node.children.entries()].map(
-    ([field, collection]) => {
-      const name = `${collection.name}_via_${field.name}`
-      const value = `${toPascalCase(collection.name)}Record[]`
+  const childrenFields = [...lookupNode.children.entries()].map(
+    ([field, childNode]) => {
+      const name = `${childNode.name}_via_${field.name}`
+      const value = `${toPascalCase(childNode.name)}Record[]`
 
       return `\t${name}?: ${value}`
     }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -60,7 +60,7 @@ export function getGenericArgForExpand(
     return "unknown"
   }
 
-  const ownerFields = [...lookupNode.parents.entries()].map(
+  const parentFields = [...lookupNode.parents.entries()].map(
     ([field, parentNode]) => {
       const value = `${toPascalCase(parentNode.name)}Record`
 
@@ -78,6 +78,6 @@ export function getGenericArgForExpand(
   )
 
   return `{
-${[...ownerFields, ...childrenFields].join(",\n")}
+${[...parentFields, ...childrenFields].join(",\n")}
 }`
 }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -70,9 +70,8 @@ export function getGenericArgForExpand(
 
   const childrenFields = [...lookupNode.children.entries()].map(
     ([field, childNode]) => {
-      const maybeArray = field.options?.maxSelect !== 1 ? "[]" : ""
       const name = `${childNode.name}_via_${field.name}`
-      const value = `${toPascalCase(childNode.name)}Record${maybeArray}`
+      const value = `${toPascalCase(childNode.name)}Record[]`
 
       return `\t${name}?: ${value}`
     }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -70,8 +70,9 @@ export function getGenericArgForExpand(
 
   const childrenFields = [...lookupNode.children.entries()].map(
     ([field, childNode]) => {
+      const maybeArray = field.options?.maxSelect !== 1 ? "[]" : ""
       const name = `${childNode.name}_via_${field.name}`
-      const value = `${toPascalCase(childNode.name)}Record[]`
+      const value = `${toPascalCase(childNode.name)}Record${maybeArray}`
 
       return `\t${name}?: ${value}`
     }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -127,11 +127,11 @@ export function createRelationshipGraph(
   const relationNodes = collections.map<RelationNode>((collection) => ({
     ...collection,
     children: new Map(),
-    owners: new Map(),
+    parents: new Map(),
   }))
 
-  relationNodes.forEach((node) => {
-    node.fields.forEach((field) => {
+  relationNodes.forEach((childNode) => {
+    childNode.fields.forEach((field) => {
       const parentId =
         field.type === "relation" ? field.options?.collectionId : undefined
 
@@ -143,8 +143,8 @@ export function createRelationshipGraph(
         return
       }
 
-      parentNode.children.set(field, node)
-      node.owners.set(field, parentNode)
+      parentNode.children.set(field, childNode)
+      childNode.parents.set(field, parentNode)
     })
   })
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -12,7 +12,12 @@ import {
   EXPAND_TYPE_DEFINITION,
   GEOPOINT_TYPE_DEFINITION,
 } from "./constants"
-import { CollectionRecord, FieldSchema } from "./types"
+import {
+  CollectionRecord,
+  FieldSchema,
+  RelationGraph,
+  RelationNode,
+} from "./types"
 import {
   createCollectionEnum,
   createCollectionRecords,
@@ -21,6 +26,7 @@ import {
 } from "./collections"
 import { createSelectOptions, createTypeField } from "./fields"
 import {
+  getGenericArgForExpand,
   getGenericArgStringForRecord,
   getGenericArgStringWithDefault,
 } from "./generics"
@@ -37,6 +43,7 @@ export function generate(
   const collectionNames: Array<string> = []
   const recordTypes: Array<string> = []
   const responseTypes: Array<string> = [RESPONSE_TYPE_COMMENT]
+  const relationGraph = createRelationshipGraph(results)
 
   results
     .sort((a, b) => (a.name <= b.name ? -1 : 1))
@@ -44,9 +51,10 @@ export function generate(
       if (row.name) collectionNames.push(row.name)
       if (row.fields) {
         recordTypes.push(createRecordType(row.name, row.fields))
-        responseTypes.push(createResponseType(row))
+        responseTypes.push(createResponseType(row, relationGraph))
       }
     })
+
   const sortedCollectionNames = collectionNames
   const includeGeoPoint = containsGeoPoint(results)
 
@@ -96,16 +104,49 @@ ${fields}
 }
 
 export function createResponseType(
-  collectionSchemaEntry: CollectionRecord
+  collectionSchemaEntry: CollectionRecord,
+  relationGraph: RelationGraph
 ): string {
   const { name, fields, type } = collectionSchemaEntry
   const pascaleName = toPascalCase(name)
   const genericArgsWithDefaults = getGenericArgStringWithDefault(fields, {
     includeExpand: true,
+    relationGraph,
+    collectionId: collectionSchemaEntry.id,
   })
   const genericArgsForRecord = getGenericArgStringForRecord(fields)
   const systemFields = getSystemFields(type)
   const expandArgString = `<T${EXPAND_GENERIC_NAME}>`
 
   return `export type ${pascaleName}Response${genericArgsWithDefaults} = Required<${pascaleName}Record${genericArgsForRecord}> & ${systemFields}${expandArgString}`
+}
+
+export function createRelationshipGraph(
+  collections: Array<CollectionRecord>
+): RelationGraph {
+  const relationNodes = collections.map<RelationNode>((collection) => ({
+    ...collection,
+    children: new Map(),
+    owners: new Map(),
+  }))
+
+  relationNodes.forEach((node) => {
+    node.fields.forEach((field) => {
+      const parentId =
+        field.type === "relation" ? field.options?.collectionId : undefined
+
+      const parentNode = parentId
+        ? relationNodes.find((collection) => collection.id === parentId)
+        : undefined
+
+      if (!parentNode) {
+        return
+      }
+
+      parentNode.children.set(field, node)
+      node.owners.set(field, parentNode)
+    })
+  })
+
+  return relationNodes
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -26,7 +26,6 @@ import {
 } from "./collections"
 import { createSelectOptions, createTypeField } from "./fields"
 import {
-  getGenericArgForExpand,
   getGenericArgStringForRecord,
   getGenericArgStringWithDefault,
 } from "./generics"

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,7 +16,7 @@ export async function fromDatabase(
   const result = await db.all("SELECT * FROM _collections")
   return result.map((collection) => ({
     ...collection,
-    fields: JSON.parse(collection.fields ?? collection.schema  ?? "{}"),
+    fields: JSON.parse(collection.fields ?? collection.schema ?? "{}"),
   }))
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type FieldSchema = {
   system: boolean
   required: boolean
   unique: boolean
+  options?: { collectionId?: string }
 } & RecordOptions
 
 export type CollectionRecord = {
@@ -55,3 +56,10 @@ export type RecordOptions = {
   pattern?: string
   values?: string[]
 }
+
+export type RelationNode = CollectionRecord & {
+  children: Map<FieldSchema, RelationNode>
+  owners: Map<FieldSchema, RelationNode>
+}
+
+export type RelationGraph = RelationNode[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type FieldSchema = {
   system: boolean
   required: boolean
   unique: boolean
-  options?: { collectionId?: string }
+  options?: { collectionId?: string; maxSelect?: number | null }
 } & RecordOptions
 
 export type CollectionRecord = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type FieldSchema = {
   system: boolean
   required: boolean
   unique: boolean
-  options?: { collectionId?: string; maxSelect?: number | null }
+  options?: { collectionId?: string }
 } & RecordOptions
 
 export type CollectionRecord = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export type RecordOptions = {
 
 export type RelationNode = CollectionRecord & {
   children: Map<FieldSchema, RelationNode>
-  owners: Map<FieldSchema, RelationNode>
+  parents: Map<FieldSchema, RelationNode>
 }
 
 export type RelationGraph = RelationNode[]

--- a/test/__snapshots__/fromJSON.test.ts.snap
+++ b/test/__snapshots__/fromJSON.test.ts.snap
@@ -36,7 +36,7 @@ type ExpandType<T> = unknown extends T
 	? T extends unknown
 		? { expand?: unknown }
 		: { expand: T }
-	: { expand: T }
+	: { expand?: T }
 
 // System fields
 export type BaseSystemFields<T = unknown> = {

--- a/test/__snapshots__/lib.test.ts.snap
+++ b/test/__snapshots__/lib.test.ts.snap
@@ -41,7 +41,7 @@ type ExpandType<T> = unknown extends T
 	? T extends unknown
 		? { expand?: unknown }
 		: { expand: T }
-	: { expand: T }
+	: { expand?: T }
 
 // System fields
 export type BaseSystemFields<T = unknown> = {

--- a/test/generics.test.ts
+++ b/test/generics.test.ts
@@ -203,8 +203,8 @@ describe("getGenericArgForExpand", () => {
       ])
 
       expect(result).toBe(`{
-\tauthor_field?: AuthorsCollectionRecord,
-\tchapters_collection_via_course_field?: ChaptersCollectionRecord[]
+\tauthor_field?: AuthorsCollectionResponse,
+\tchapters_collection_via_course_field?: ChaptersCollectionResponse[]
 }`)
 
       const result2 = getGenericArgForExpand(authors.id, [
@@ -214,7 +214,7 @@ describe("getGenericArgForExpand", () => {
       ])
 
       expect(result2).toBe(`{
-\tcourses_collection_via_author_field?: CoursesCollectionRecord[]
+\tcourses_collection_via_author_field?: CoursesCollectionResponse[]
 }`)
     })
 
@@ -226,9 +226,9 @@ describe("getGenericArgForExpand", () => {
       ])
 
       expect(result).toBe(`{
-\tcourse_field?: CoursesCollectionRecord,
-\tparent_chapter?: ChaptersCollectionRecord,
-\tchapters_collection_via_parent_chapter?: ChaptersCollectionRecord[]
+\tcourse_field?: CoursesCollectionResponse,
+\tparent_chapter?: ChaptersCollectionResponse,
+\tchapters_collection_via_parent_chapter?: ChaptersCollectionResponse[]
 }`)
     })
   })

--- a/test/generics.test.ts
+++ b/test/generics.test.ts
@@ -155,15 +155,13 @@ describe("getGenericArgForExpand", () => {
   const addRelationship = (
     parentNode: RelationNode,
     childNode: RelationNode,
-    fieldName: string,
-    maxSelect?: number
+    fieldName: string
   ) => {
     const field = mockField({
       name: fieldName,
       type: "relation",
       options: {
         collectionId: parentNode.id,
-        maxSelect: maxSelect ?? null,
       },
     })
     childNode.fields.push(field)
@@ -195,7 +193,7 @@ describe("getGenericArgForExpand", () => {
 
     addRelationship(authors, courses, "author_field")
     addRelationship(courses, chapters, "course_field")
-    addRelationship(chapters, chapters, "parent_chapter", 1)
+    addRelationship(chapters, chapters, "parent_chapter")
 
     it("generates expand type for collection with owner relationships", () => {
       const result = getGenericArgForExpand(courses.id, [
@@ -230,7 +228,7 @@ describe("getGenericArgForExpand", () => {
       expect(result).toBe(`{
 \tcourse_field?: CoursesCollectionRecord,
 \tparent_chapter?: ChaptersCollectionRecord,
-\tchapters_collection_via_parent_chapter?: ChaptersCollectionRecord
+\tchapters_collection_via_parent_chapter?: ChaptersCollectionRecord[]
 }`)
     })
   })

--- a/test/generics.test.ts
+++ b/test/generics.test.ts
@@ -155,13 +155,15 @@ describe("getGenericArgForExpand", () => {
   const addRelationship = (
     parentNode: RelationNode,
     childNode: RelationNode,
-    fieldName: string
+    fieldName: string,
+    maxSelect?: number
   ) => {
     const field = mockField({
       name: fieldName,
       type: "relation",
       options: {
         collectionId: parentNode.id,
+        maxSelect: maxSelect ?? null,
       },
     })
     childNode.fields.push(field)
@@ -193,7 +195,7 @@ describe("getGenericArgForExpand", () => {
 
     addRelationship(authors, courses, "author_field")
     addRelationship(courses, chapters, "course_field")
-    addRelationship(chapters, chapters, "parent_chapter")
+    addRelationship(chapters, chapters, "parent_chapter", 1)
 
     it("generates expand type for collection with owner relationships", () => {
       const result = getGenericArgForExpand(courses.id, [
@@ -228,7 +230,7 @@ describe("getGenericArgForExpand", () => {
       expect(result).toBe(`{
 \tcourse_field?: CoursesCollectionRecord,
 \tparent_chapter?: ChaptersCollectionRecord,
-\tchapters_collection_via_parent_chapter?: ChaptersCollectionRecord[]
+\tchapters_collection_via_parent_chapter?: ChaptersCollectionRecord
 }`)
     })
   })

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -267,30 +267,35 @@ describe("createRelationshipGraph", () => {
 
     expect(chapterNode.children.size).toBe(1)
     expect(chapterNode.parents.size).toBe(2)
-    const [[chapterChildrenField, chapterChildrenCollection]] = chapterNode.children
+    const [[chapterChildrenField, chapterChildrenCollection]] =
+      chapterNode.children
     expect(chapterChildrenField.name).toBe("parent")
     expect(chapterChildrenCollection).toBe(chapterNode)
-    const [[chapterOwnerField1, chapterOwner1], [chapterOwnerField2,chapterOwner2]] = chapterNode.parents
+    const [
+      [chapterOwnerField1, chapterOwner1],
+      [chapterOwnerField2, chapterOwner2],
+    ] = chapterNode.parents
     expect(chapterOwner1).toBe(courseNode)
-    expect(chapterOwnerField1.name).toBe('course')
+    expect(chapterOwnerField1.name).toBe("course")
     expect(chapterOwner2).toBe(chapterNode)
-    expect(chapterOwnerField2.name).toBe('parent')
+    expect(chapterOwnerField2.name).toBe("parent")
 
     expect(courseNode.children.size).toBe(1)
     expect(courseNode.parents.size).toBe(1)
-    const [[courseChildrenField, courseChildrenCollection]] = courseNode.children
+    const [[courseChildrenField, courseChildrenCollection]] =
+      courseNode.children
     expect(courseChildrenField.name).toBe("course")
     expect(courseChildrenCollection).toBe(chapterNode)
     const [[courseOwnerField1, courseOwner1]] = courseNode.parents
     expect(courseOwner1).toBe(authorNode)
-    expect(courseOwnerField1.name).toBe('author')
+    expect(courseOwnerField1.name).toBe("author")
 
     expect(authorNode.children.size).toBe(1)
     expect(authorNode.parents.size).toBe(0)
-    const [[authorChildrenField, authorChildrenCollection]] = authorNode.children
+    const [[authorChildrenField, authorChildrenCollection]] =
+      authorNode.children
     expect(authorChildrenField.name).toBe("author")
     expect(authorChildrenCollection).toBe(courseNode)
-
   })
 
   it("handles broken relationship references gracefully", () => {

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -1,5 +1,10 @@
 import { CollectionRecord, FieldSchema } from "../src/types"
-import { createRecordType, createResponseType, generate } from "../src/lib"
+import {
+  createRecordType,
+  createRelationshipGraph,
+  createResponseType,
+  generate,
+} from "../src/lib"
 
 describe("generate", () => {
   it("generates correct output given db input", () => {
@@ -152,7 +157,7 @@ describe("createResponseType", () => {
       viewRule: null,
     }
 
-    const result = createResponseType(row)
+    const result = createResponseType(row, [])
     expect(result).toMatchSnapshot()
   })
 
@@ -171,5 +176,119 @@ describe("createResponseType", () => {
     ]
     const result = createRecordType(name, schema)
     expect(result).toMatchSnapshot()
+  })
+})
+
+describe("createRelationshipGraph", () => {
+  const mockField = ({
+    id,
+    name,
+    type,
+    ...rest
+  }: Pick<FieldSchema, "id" | "name" | "type"> &
+    Partial<Omit<FieldSchema, "id" | "name" | "type">>): FieldSchema => ({
+    id,
+    name,
+    type,
+    required: false,
+    system: false,
+    unique: false,
+    ...rest,
+  })
+
+  const mockCollection = (
+    overrides: Partial<CollectionRecord>
+  ): CollectionRecord => ({
+    id: "default_id",
+    name: "default_name",
+    type: "base",
+    system: false,
+    fields: [],
+    createRule: null,
+    deleteRule: null,
+    listRule: null,
+    updateRule: null,
+    viewRule: null,
+    ...overrides,
+  })
+
+  it("creates empty graph from empty collections", () => {
+    const result = createRelationshipGraph([])
+    expect(result).toEqual([])
+  })
+
+  it("creates graph with no relationships for standalone collections", () => {
+    const collections = [
+      mockCollection({ id: "1", name: "users" }),
+      mockCollection({ id: "2", name: "posts" }),
+    ]
+    const graph = createRelationshipGraph(collections)
+
+    expect(graph).toHaveLength(2)
+    expect(graph[0].children.size).toBe(0)
+    expect(graph[0].owners.size).toBe(0)
+    expect(graph[1].children.size).toBe(0)
+    expect(graph[1].owners.size).toBe(0)
+  })
+
+  it("creates parent-child relationships correctly", () => {
+    const authorCollection = mockCollection({
+      id: "collection1",
+      name: "authors",
+      fields: [mockField({ id: "1", name: "name", type: "text" })],
+    })
+    const bookCollection = mockCollection({
+      id: "collection2",
+      name: "books",
+      fields: [
+        mockField({ id: "1", name: "title", type: "text" }),
+        mockField({
+          id: "1",
+          name: "author",
+          type: "relation",
+          options: {
+            collectionId: "collection1",
+          },
+        }),
+      ],
+    })
+    const graph = createRelationshipGraph([authorCollection, bookCollection])
+    console.log("🤖 graph", graph[1].fields)
+
+    const authorNode = graph.find((n) => n.id === authorCollection.id)!
+    const bookNode = graph.find((n) => n.id === bookCollection.id)!
+
+    expect(bookNode.children.size).toBe(0)
+
+    expect(authorNode.children.size).toBe(1)
+    const [[, authorChildrenCollection]] = authorNode.children
+    expect(authorChildrenCollection).toBe(bookNode)
+
+    expect(bookNode.owners.size).toBe(1)
+    const [[, bookOwnerCollection]] = bookNode.owners
+    expect(bookOwnerCollection).toBe(authorNode)
+  })
+
+  it("handles broken relationship references gracefully", () => {
+    const collections = [
+      mockCollection({
+        id: "post_id",
+        name: "posts",
+        fields: [
+          mockField({
+            id: "1",
+            name: "author",
+            type: "relation",
+            options: {
+              collectionId: "non_existent_id",
+            },
+          }),
+        ],
+      }),
+    ]
+
+    const graph = createRelationshipGraph(collections)
+    expect(graph[0].owners.size).toBe(0)
+    expect(graph[0].children.size).toBe(0)
   })
 })

--- a/test/pocketbase-types-example.ts
+++ b/test/pocketbase-types-example.ts
@@ -33,7 +33,7 @@ type ExpandType<T> = unknown extends T
 	? T extends unknown
 		? { expand?: unknown }
 		: { expand: T }
-	: { expand: T }
+	: { expand?: T }
 
 // System fields
 export type BaseSystemFields<T = unknown> = {


### PR DESCRIPTION
This PR adds support for mapping `TExpand` field with actual relationships between types.

For example, given 3 collections:

Author -> (has many) -> Courses -> (has many) Chapters -> (has many) (sub) Chapters

<img width="1215" height="309" alt="image" src="https://github.com/user-attachments/assets/bbdbaa9c-3a05-42e3-95af-1231fceec905" />

It would generate following schema:

```ts
export type AuthorsResponse<Texpand = {
	courses_via_author?: CoursesRecord[]
}> = Required<AuthorsRecord> & BaseSystemFields<Texpand>
export type ChaptersResponse<Texpand = {
	course?: CoursesRecord,
	parent?: ChaptersRecord,
	chapters_via_parent?: ChaptersRecord[],
}> = Required<ChaptersRecord> & BaseSystemFields<Texpand>
export type CoursesResponse<Texpand = {
	author?: AuthorsRecord,
	chapters_via_course?: ChaptersRecord[]
}> = Required<CoursesRecord> & BaseSystemFields<Texpand>
```