### PR TITLE
Fixes the issue in the type generation for reference field 

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -35,9 +35,9 @@ export const pbSchemaTypescriptMap = {
   json: (fieldSchema: FieldSchema) =>
     `null | ${fieldNameToGeneric(fieldSchema.name)}`,
   relation: (fieldSchema: FieldSchema) =>
-    fieldSchema.maxSelect && fieldSchema.maxSelect === 1
-      ? RECORD_ID_STRING_NAME
-      : `${RECORD_ID_STRING_NAME}[]`,
+    fieldSchema.maxSelect && fieldSchema.maxSelect > 1
+      ? `${RECORD_ID_STRING_NAME}[]`
+      : RECORD_ID_STRING_NAME,
   select: (fieldSchema: FieldSchema, collectionName: string) => {
     // pocketbase v0.8+ values are required
     const valueType = fieldSchema.values

--- a/test/fields.test.ts
+++ b/test/fields.test.ts
@@ -189,7 +189,7 @@ describe("createTypeField", () => {
         name: "relationField",
         type: "relation",
       })
-    ).toEqual("\trelationField: RecordIdString[]")
+    ).toEqual("\trelationField: RecordIdString")
   })
 
   it("converts relation type with multiple options", () => {
@@ -211,7 +211,7 @@ describe("createTypeField", () => {
         maxSelect: null,
         type: "relation",
       })
-    ).toEqual("\trelationFieldMany: RecordIdString[]")
+    ).toEqual("\trelationFieldMany: RecordIdString")
   })
 
   // DEPRECATED: This was removed in PocketBase v0.8


### PR DESCRIPTION
Fixed the issue in the type generation for newer behavior post the pocketbase v0.23, 

Based on this -> https://github.com/patmood/pocketbase-typegen/issues/146#issuecomment-3660874810

i have updated the logic for the handling the reference fields and updated the following tests 

1. Converts relation type -> this test now expects RecordIdString (single) , instead of RecordIdString[]
as here maxSelect is undefined and the only possible way for the RecordIdString[] is when the maxSelect > 1 

2. converts relation type with unset maxSelect -> Same for this too, as this explicitly sets the maxSelect to be null 
